### PR TITLE
ログイン機能実装（STEP1）

### DIFF
--- a/frontend/src/components/atoms/button/PrimaryButton.tsx
+++ b/frontend/src/components/atoms/button/PrimaryButton.tsx
@@ -4,17 +4,19 @@ import { Button } from '@chakra-ui/button';
 type Props = {
   children: ReactNode;
   disabled?: boolean;
+  loading?: boolean;
   onClick: () => void;
 };
 
 export const PrimaryButton: VFC<Props> = memo((props) => {
-  const { children, disabled = false, onClick } = props;
+  const { children, disabled = false, loading = false, onClick } = props;
   return (
     <Button
       bg="brand"
       color="white"
       _hover={{ opacity: 0.8 }}
-      disabled={disabled}
+      disabled={disabled || loading}
+      isLoading={loading}
       onClick={onClick}
     >
       {children}

--- a/frontend/src/components/atoms/button/PrimaryButton.tsx
+++ b/frontend/src/components/atoms/button/PrimaryButton.tsx
@@ -3,12 +3,18 @@ import { Button } from '@chakra-ui/button';
 
 type Props = {
   children: ReactNode;
+  onClick: () => void;
 };
 
 export const PrimaryButton: VFC<Props> = memo((props) => {
-  const { children } = props;
+  const { children, onClick } = props;
   return (
-    <Button bg="brand" color="white" _hover={{ opacity: 0.8 }}>
+    <Button
+      bg="brand"
+      color="white"
+      _hover={{ opacity: 0.8 }}
+      onClick={onClick}
+    >
       {children}
     </Button>
   );

--- a/frontend/src/components/atoms/button/PrimaryButton.tsx
+++ b/frontend/src/components/atoms/button/PrimaryButton.tsx
@@ -3,16 +3,18 @@ import { Button } from '@chakra-ui/button';
 
 type Props = {
   children: ReactNode;
+  disabled?: boolean;
   onClick: () => void;
 };
 
 export const PrimaryButton: VFC<Props> = memo((props) => {
-  const { children, onClick } = props;
+  const { children, disabled = false, onClick } = props;
   return (
     <Button
       bg="brand"
       color="white"
       _hover={{ opacity: 0.8 }}
+      disabled={disabled}
       onClick={onClick}
     >
       {children}

--- a/frontend/src/components/pages/Login.tsx
+++ b/frontend/src/components/pages/Login.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable arrow-body-style */
 import { ChangeEvent, memo, useCallback, useState, VFC } from 'react';
 import {
@@ -16,9 +17,13 @@ import { PrimaryButton } from 'components/atoms/button/PrimaryButton';
 import { GuestButton } from 'components/atoms/button/GuestButton';
 import { NewRegistrationButton } from 'components/atoms/button/NewRegistrationButton';
 import { useHistory } from 'react-router-dom';
+import { useAuth } from 'hooks/useAuth';
 
 export const Login: VFC = memo(() => {
+  const { login, loading } = useAuth();
+
   const history = useHistory();
+
   const onClickHome = useCallback(
     () => history.push('/restaurants'),
     [history]
@@ -26,8 +31,11 @@ export const Login: VFC = memo(() => {
 
   // ユーザーID用State
   const [userId, setUserId] = useState('');
+
   const onChangeUserId = (e: ChangeEvent<HTMLInputElement>) =>
     setUserId(e.target.value);
+
+  const onClickLogin = () => login(userId);
 
   return (
     <Flex align="center" justify="center" height="100vh">
@@ -60,7 +68,7 @@ export const Login: VFC = memo(() => {
             _placeholder={{ color: 'gray.300' }}
             _hover={{ color: 'gray.600' }}
           />
-          <PrimaryButton>ログイン</PrimaryButton>
+          <PrimaryButton onClick={onClickLogin}>ログイン</PrimaryButton>
           <GuestButton>ゲストログイン</GuestButton>
           <NewRegistrationButton>新規登録</NewRegistrationButton>
         </Stack>

--- a/frontend/src/components/pages/Login.tsx
+++ b/frontend/src/components/pages/Login.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable arrow-body-style */
-import { memo, useCallback, VFC } from 'react';
+import { ChangeEvent, memo, useCallback, useState, VFC } from 'react';
 import {
   Image,
   Input,
@@ -24,6 +24,11 @@ export const Login: VFC = memo(() => {
     [history]
   );
 
+  // ユーザーID用State
+  const [userId, setUserId] = useState('');
+  const onChangeUserId = (e: ChangeEvent<HTMLInputElement>) =>
+    setUserId(e.target.value);
+
   return (
     <Flex align="center" justify="center" height="100vh">
       <Box bg="white" w="sm" p={4} borderRaius="md" shadow="md">
@@ -46,6 +51,8 @@ export const Login: VFC = memo(() => {
             placeholder="ユーザーID"
             _placeholder={{ color: 'gray.300' }}
             _hover={{ color: 'gray.600' }}
+            value={userId}
+            onChange={onChangeUserId}
           />
           <Input
             borderColor="gray.300"

--- a/frontend/src/components/pages/Login.tsx
+++ b/frontend/src/components/pages/Login.tsx
@@ -68,7 +68,11 @@ export const Login: VFC = memo(() => {
             _placeholder={{ color: 'gray.300' }}
             _hover={{ color: 'gray.600' }}
           />
-          <PrimaryButton disabled={userId === ''} onClick={onClickLogin}>
+          <PrimaryButton
+            disabled={userId === ''}
+            loading={loading}
+            onClick={onClickLogin}
+          >
             ログイン
           </PrimaryButton>
           <GuestButton>ゲストログイン</GuestButton>

--- a/frontend/src/components/pages/Login.tsx
+++ b/frontend/src/components/pages/Login.tsx
@@ -68,7 +68,9 @@ export const Login: VFC = memo(() => {
             _placeholder={{ color: 'gray.300' }}
             _hover={{ color: 'gray.600' }}
           />
-          <PrimaryButton onClick={onClickLogin}>ログイン</PrimaryButton>
+          <PrimaryButton disabled={userId === ''} onClick={onClickLogin}>
+            ログイン
+          </PrimaryButton>
           <GuestButton>ゲストログイン</GuestButton>
           <NewRegistrationButton>新規登録</NewRegistrationButton>
         </Stack>

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,11 +1,26 @@
+/* eslint-disable arrow-body-style */
 import axios from 'axios';
 import { useCallback } from 'react';
+import { useHistory } from 'react-router-dom';
 
 import { User } from 'types/api/user';
 
 export const useAuth = () => {
-  const login = useCallback((id: string) => {
-    axios.get<User>(`https://jsonplaceholder.typicode.com/users/${id}`);
-  }, []);
+  const history = useHistory();
+  const login = useCallback(
+    (id: string) => {
+      axios
+        .get<User>(`https://jsonplaceholder.typicode.com/users/${id}`)
+        .then((res) => {
+          if (res.data) {
+            history.push('/restaurants');
+          } else {
+            alert('ユーザーが見つかりません');
+          }
+        })
+        .catch(() => alert('ログインできません'));
+    },
+    [history]
+  );
   return { login };
 };

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,0 +1,9 @@
+import axios from 'axios';
+import { useCallback } from 'react';
+
+export const useAuth = () => {
+  const login = useCallback((id: string) => {
+    axios.get<>(`https://jsonplaceholder.typicode.com/users/${id}`);
+  }, []);
+  return { login };
+};

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -27,5 +27,5 @@ export const useAuth = () => {
     },
     [history]
   );
-  return { login };
+  return { login, loading };
 };

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,14 +1,18 @@
 /* eslint-disable arrow-body-style */
 import axios from 'axios';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { User } from 'types/api/user';
 
 export const useAuth = () => {
   const history = useHistory();
+
+  const [loading, setLoading] = useState(false);
+
   const login = useCallback(
     (id: string) => {
+      setLoading(true);
       axios
         .get<User>(`https://jsonplaceholder.typicode.com/users/${id}`)
         .then((res) => {
@@ -18,7 +22,8 @@ export const useAuth = () => {
             alert('ユーザーが見つかりません');
           }
         })
-        .catch(() => alert('ログインできません'));
+        .catch(() => alert('ログインできません'))
+        .finally(() => setLoading(false));
     },
     [history]
   );

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,9 +1,11 @@
 import axios from 'axios';
 import { useCallback } from 'react';
 
+import { User } from 'types/api/user';
+
 export const useAuth = () => {
   const login = useCallback((id: string) => {
-    axios.get<>(`https://jsonplaceholder.typicode.com/users/${id}`);
+    axios.get<User>(`https://jsonplaceholder.typicode.com/users/${id}`);
   }, []);
   return { login };
 };

--- a/frontend/src/types/api/user.ts
+++ b/frontend/src/types/api/user.ts
@@ -1,0 +1,23 @@
+export type User = {
+  id: number;
+  name: string;
+  username: string;
+  email: string;
+  address: {
+    street: string;
+    suite: string;
+    city: string;
+    zipcode: string;
+    geo: {
+      lat: string;
+      lng: string;
+    };
+  };
+  phone: string;
+  website: string;
+  company: {
+    name: string;
+    catchPhrase: string;
+    bs: string;
+  };
+};


### PR DESCRIPTION
## issue
close #29 

## 実装の目的と概要
-  ログイン機能実装工程をSTEP1とSTEP2に分割し、STEP1として実装
  - STEP1では、フロント側でJsonplaceholderを使用し、仮のユーザーIDのみで認証する仕組みを実装する

## 実装内容(技術的な点を記載)
- Inputボックスに入力された値を引数にJsonplaceholderのAPIを呼び出して、ログインボタンを押下した際、以下の動作・機能を実装
  - Inputフォームが空欄の場合はログインボタンを非活性とする
  - Inputフォームに該当しないユーザーIDを入力した場合はアラート表示＋ログインさせない
  - Inputフォームに該当するユーザーIDを入力した場合はホーム画面へ遷移
  - ログイン処理中はローディングを表示する
  - ローディング中は非活性
- ログイン可能なユーザーID
  - ユーザーID：1~10のみ（それ以外はログインできない仕様です） 

## 画像
- ログインボタンの動作

https://user-images.githubusercontent.com/42578729/142433078-4f693877-3d50-4de3-9bd8-169d3829a92a.mov


## 今後の学習課題や記録しておくこと
- STEP2で引き続き、ログイン機能実装 #6 
  - ユーザーIDをe-mailに変更する
  - passwordのInputフォームも合わせて判定する

## チェックリスト
- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか