### PR TITLE
[フロント]メッセージ表示機能実装

### DIFF
--- a/frontend/src/components/pages/Login.tsx
+++ b/frontend/src/components/pages/Login.tsx
@@ -69,7 +69,7 @@ export const Login: VFC = memo(() => {
             _hover={{ color: 'gray.600' }}
           />
           <PrimaryButton
-            disabled={userId === ''}
+            disabled={!userId}
             loading={loading}
             onClick={onClickLogin}
           >

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -16,7 +16,7 @@ export const useAuth = () => {
       axios
         .get<User>(`https://jsonplaceholder.typicode.com/users/${id}`)
         .then((res) => {
-          if (res.data) {
+          if (res.data.id) {
             history.push('/restaurants');
           } else {
             alert('ユーザーが見つかりません');

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -17,22 +17,12 @@ export const useAuth = () => {
       setLoading(true);
       axios
         .get<User>(`https://jsonplaceholder.typicode.com/users/${id}`)
-        .then((res) => {
-          if (res.data.id) {
-            showMessage({ title: 'ログインしました', status: 'success' });
-            history.push('/restaurants');
-          } else {
-            showMessage({
-              title: 'ユーザーが見つかりません',
-              status: 'error',
-            });
-          }
+        .then(() => {
+          showMessage({ title: 'ログインしました', status: 'success' });
+          history.push('/restaurants');
         })
         .catch(() =>
-          showMessage({
-            title: 'ログインできません',
-            status: 'error',
-          })
+          showMessage({ title: 'ログインできません', status: 'error' })
         )
         .finally(() => setLoading(false));
     },

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -4,9 +4,11 @@ import { useCallback, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { User } from 'types/api/user';
+import { useMessage } from './useMessage';
 
 export const useAuth = () => {
   const history = useHistory();
+  const { showMessage } = useMessage();
 
   const [loading, setLoading] = useState(false);
 
@@ -17,6 +19,7 @@ export const useAuth = () => {
         .get<User>(`https://jsonplaceholder.typicode.com/users/${id}`)
         .then((res) => {
           if (res.data.id) {
+            showMessage({ title: 'ログインしました', status: 'success' });
             history.push('/restaurants');
           } else {
             alert('ユーザーが見つかりません');

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -22,7 +22,11 @@ export const useAuth = () => {
           history.push('/restaurants');
         })
         .catch(() =>
-          showMessage({ title: 'ログインできません', status: 'error' })
+          showMessage({
+            title:
+              'ユーザID、パスワードの入力に誤りがあるか登録されていません。',
+            status: 'error',
+          })
         )
         .finally(() => setLoading(false));
     },

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -22,13 +22,21 @@ export const useAuth = () => {
             showMessage({ title: 'ログインしました', status: 'success' });
             history.push('/restaurants');
           } else {
-            alert('ユーザーが見つかりません');
+            showMessage({
+              title: 'ユーザーが見つかりません',
+              status: 'error',
+            });
           }
         })
-        .catch(() => alert('ログインできません'))
+        .catch(() =>
+          showMessage({
+            title: 'ログインできません',
+            status: 'error',
+          })
+        )
         .finally(() => setLoading(false));
     },
-    [history]
+    [history, showMessage]
   );
   return { login, loading };
 };

--- a/frontend/src/hooks/useMessage.ts
+++ b/frontend/src/hooks/useMessage.ts
@@ -1,0 +1,26 @@
+import { useCallback } from 'react';
+import { useToast } from '@chakra-ui/toast';
+
+type Props = {
+  title: string;
+  status: 'info' | 'warning' | 'success' | 'error';
+};
+
+export const useMessage = () => {
+  const toast = useToast();
+
+  const showMessage = useCallback(
+    (props: Props) => {
+      const { title, status } = props;
+      toast({
+        title,
+        status,
+        position: 'top',
+        duration: 2000,
+        isClosable: true,
+      });
+    },
+    [toast]
+  );
+  return { showMessage };
+};


### PR DESCRIPTION
## issue
close #32 

## 実装の目的と概要
-  ログイン画面のalert表示をメッセージ表示に変更する

## 実装内容(技術的な点を記載)
- chakra-ui toastを使用する
- custom hooksを作成する
- id:1~10であればログイン可と設定

## 画像（実装前後の比較など）
- 以下のパターンを動画内でテストしています
  - 何も入力していない状態でのログインボタン（結果：非活性）
  - 不正なログインIDを入力した場合のメッセージ表記（結果：error）
  - 空欄を入力した場合のメッセージ表記（結果：error）
  - 正しいログインIDを入力した場合のメッセージ表記（結果：success）

https://user-images.githubusercontent.com/42578729/142629355-da8f29a7-3e5b-46d1-89cc-5e97449ad607.mov

## チェックリスト
- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
