### PR TITLE
[フロント]Food選択時のモーダル実装

### DIFF
--- a/frontend/src/components/atoms/button/CountDownButton.tsx
+++ b/frontend/src/components/atoms/button/CountDownButton.tsx
@@ -1,0 +1,26 @@
+import { memo, VFC } from 'react';
+import { Button } from '@chakra-ui/button';
+
+type Props = {
+  onClick: () => void;
+  isDisabled: boolean;
+};
+
+export const CountDownButton: VFC<Props> = memo((props) => {
+  const { onClick, isDisabled } = props;
+  return (
+    <Button
+      fontSize="2xl"
+      p={2}
+      ml={-3}
+      bg={'gray.100'}
+      shadow="md"
+      rounded="full"
+      _hover={{ opacity: 0.8 }}
+      onClick={onClick}
+      disabled={isDisabled}
+    >
+      -
+    </Button>
+  );
+});

--- a/frontend/src/components/atoms/button/CountUpButton.tsx
+++ b/frontend/src/components/atoms/button/CountUpButton.tsx
@@ -1,0 +1,26 @@
+import { memo, VFC } from 'react';
+import { Button } from '@chakra-ui/button';
+
+type Props = {
+  onClick: () => void;
+  isDisabled: boolean;
+};
+
+export const CountUpButton: VFC<Props> = memo((props) => {
+  const { onClick, isDisabled } = props;
+  return (
+    <Button
+      fontSize="2xl"
+      p={2}
+      mr={6}
+      bg={'gray.100'}
+      shadow="md"
+      rounded="full"
+      _hover={{ opacity: 0.8 }}
+      onClick={onClick}
+      disabled={isDisabled}
+    >
+      +
+    </Button>
+  );
+});

--- a/frontend/src/components/atoms/button/OrderButton.tsx
+++ b/frontend/src/components/atoms/button/OrderButton.tsx
@@ -1,0 +1,27 @@
+import { memo, ReactNode, VFC } from 'react';
+import { Button } from '@chakra-ui/button';
+
+type Props = {
+  children: ReactNode;
+  disabled?: boolean;
+  loading?: boolean;
+  onClick: () => void;
+};
+
+export const OrderButton: VFC<Props> = memo((props) => {
+  const { children, disabled = false, loading = false, onClick } = props;
+  return (
+    <Button
+      size="lg"
+      mr={-3}
+      bg="brand"
+      color="white"
+      _hover={{ opacity: 0.8 }}
+      disabled={disabled || loading}
+      isLoading={loading}
+      onClick={onClick}
+    >
+      {children}
+    </Button>
+  );
+});

--- a/frontend/src/components/organisms/food/FoodCard.tsx
+++ b/frontend/src/components/organisms/food/FoodCard.tsx
@@ -19,6 +19,7 @@ export const FoodCard: VFC<Props> = memo((props) => {
       w="260px"
       h="260px"
       bg="white"
+      borderRadius="10px"
       shadow="md"
       p={4}
       _hover={{ cursor: 'pointer', opacity: 0.8 }}

--- a/frontend/src/components/organisms/food/FoodCard.tsx
+++ b/frontend/src/components/organisms/food/FoodCard.tsx
@@ -1,16 +1,19 @@
+/* eslint-disable arrow-body-style */
 import { Image } from '@chakra-ui/image';
 import { Box, Stack, Text } from '@chakra-ui/layout';
 import { memo, VFC } from 'react';
 
 type Props = {
+  id: number;
   imageUrl: string;
   foodName: string;
   foodDescription: string;
   foodPrice: number;
+  onClick: (id: number) => void;
 };
 
 export const FoodCard: VFC<Props> = memo((props) => {
-  const { imageUrl, foodName, foodDescription, foodPrice } = props;
+  const { id, imageUrl, foodName, foodDescription, foodPrice, onClick } = props;
   return (
     <Box
       w="260px"
@@ -20,6 +23,7 @@ export const FoodCard: VFC<Props> = memo((props) => {
       shadow="md"
       p={4}
       _hover={{ cursor: 'pointer', opacity: 0.8 }}
+      onClick={() => onClick(id)}
     >
       <Stack textAlign="center" />
       <Image src={imageUrl} alt={foodName} />

--- a/frontend/src/components/organisms/food/FoodCard.tsx
+++ b/frontend/src/components/organisms/food/FoodCard.tsx
@@ -19,7 +19,6 @@ export const FoodCard: VFC<Props> = memo((props) => {
       w="260px"
       h="260px"
       bg="white"
-      borderRadius="10px"
       shadow="md"
       p={4}
       _hover={{ cursor: 'pointer', opacity: 0.8 }}

--- a/frontend/src/components/organisms/food/FoodDetailModal.tsx
+++ b/frontend/src/components/organisms/food/FoodDetailModal.tsx
@@ -1,0 +1,48 @@
+import { FormControl, FormLabel } from '@chakra-ui/form-control';
+import { Input } from '@chakra-ui/input';
+import { Stack } from '@chakra-ui/layout';
+import {
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+} from '@chakra-ui/modal';
+import { memo, VFC } from 'react';
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+export const FoodDetailModal: VFC<Props> = memo((props) => {
+  const { isOpen, onClose } = props;
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      autoFocus={false}
+      motionPreset="slideInBottom"
+    >
+      <ModalOverlay>
+        <ModalContent bg="white" pb={6}>
+          <ModalHeader>注文</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody mx={4}>
+            <Stack spacing={4}>
+              <FormControl>
+                <FormLabel>商品名</FormLabel>
+                <Input value="テスト" isReadOnly />
+              </FormControl>
+              <FormControl>
+                <FormLabel>MAIL</FormLabel>
+                <Input value="test@exapmle.com" isReadOnly />
+              </FormControl>
+            </Stack>
+          </ModalBody>
+        </ModalContent>
+      </ModalOverlay>
+    </Modal>
+  );
+});

--- a/frontend/src/components/organisms/food/FoodOrderModal.tsx
+++ b/frontend/src/components/organisms/food/FoodOrderModal.tsx
@@ -11,13 +11,16 @@ import {
 } from '@chakra-ui/modal';
 import { memo, VFC } from 'react';
 
+import { Food } from 'types/api/food';
+
 type Props = {
+  food: Food | null;
   isOpen: boolean;
   onClose: () => void;
 };
 
-export const FoodDetailModal: VFC<Props> = memo((props) => {
-  const { isOpen, onClose } = props;
+export const FoodOrderModal: VFC<Props> = memo((props) => {
+  const { food, isOpen, onClose } = props;
   return (
     <Modal
       isOpen={isOpen}
@@ -32,12 +35,20 @@ export const FoodDetailModal: VFC<Props> = memo((props) => {
           <ModalBody mx={4}>
             <Stack spacing={4}>
               <FormControl>
-                <FormLabel>商品名</FormLabel>
-                <Input value="テスト" isReadOnly />
+                <FormLabel>画像</FormLabel>
+                <Input value={food?.image} isReadOnly />
               </FormControl>
               <FormControl>
-                <FormLabel>MAIL</FormLabel>
-                <Input value="test@exapmle.com" isReadOnly />
+                <FormLabel>商品名</FormLabel>
+                <Input value={food?.name} isReadOnly />
+              </FormControl>
+              <FormControl>
+                <FormLabel>商品説明</FormLabel>
+                <Input value={food?.food_description} isReadOnly />
+              </FormControl>
+              <FormControl>
+                <FormLabel>金額</FormLabel>
+                <Input value={food?.price} isReadOnly />
               </FormControl>
             </Stack>
           </ModalBody>

--- a/frontend/src/components/organisms/food/FoodOrderModal.tsx
+++ b/frontend/src/components/organisms/food/FoodOrderModal.tsx
@@ -41,6 +41,7 @@ export const FoodOrderModal: VFC<Props> = memo((props) => {
 
   return (
     <Modal
+      size="lg"
       isOpen={isOpen}
       onClose={onClose}
       autoFocus={false}
@@ -49,7 +50,11 @@ export const FoodOrderModal: VFC<Props> = memo((props) => {
       <ModalOverlay>
         <ModalContent bg="white">
           <Image src={BeefTongue} />
-          <ModalCloseButton />
+          <ModalCloseButton
+            bgColor="white"
+            rounded="full"
+            _hover={{ opacity: 0.8 }}
+          />
           <ModalBody mx={2}>
             <Stack spacing={2}>
               <FormControl>

--- a/frontend/src/components/organisms/food/FoodOrderModal.tsx
+++ b/frontend/src/components/organisms/food/FoodOrderModal.tsx
@@ -1,26 +1,44 @@
-import { FormControl, FormLabel } from '@chakra-ui/form-control';
-import { Input } from '@chakra-ui/input';
-import { Stack } from '@chakra-ui/layout';
+/* eslint-disable arrow-body-style */
+import { memo, VFC } from 'react';
+import { FormControl } from '@chakra-ui/form-control';
+import { Spacer, Stack, Text } from '@chakra-ui/layout';
 import {
   Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
-  ModalHeader,
+  ModalFooter,
   ModalOverlay,
 } from '@chakra-ui/modal';
-import { memo, VFC } from 'react';
+import { CountDownButton } from 'components/atoms/button/CountDownButton';
+import { CountUpButton } from 'components/atoms/button/CountUpButton';
+import { OrderButton } from 'components/atoms/button/OrderButton';
 
 import { Food } from 'types/api/food';
+import BeefTongue from 'images/BeefTongue.svg';
+import { Image } from '@chakra-ui/image';
 
 type Props = {
   food: Food | null;
+  countNumber: number;
   isOpen: boolean;
   onClose: () => void;
+  onClickUpCount: () => void;
+  onClickDownCount: () => void;
+  onClickOrder: () => void;
 };
 
 export const FoodOrderModal: VFC<Props> = memo((props) => {
-  const { food, isOpen, onClose } = props;
+  const {
+    food,
+    countNumber,
+    isOpen,
+    onClose,
+    onClickUpCount,
+    onClickDownCount,
+    onClickOrder,
+  } = props;
+
   return (
     <Modal
       isOpen={isOpen}
@@ -29,29 +47,45 @@ export const FoodOrderModal: VFC<Props> = memo((props) => {
       motionPreset="slideInBottom"
     >
       <ModalOverlay>
-        <ModalContent bg="white" pb={6}>
-          <ModalHeader>注文</ModalHeader>
+        <ModalContent bg="white">
+          <Image src={BeefTongue} />
           <ModalCloseButton />
-          <ModalBody mx={4}>
-            <Stack spacing={4}>
+          <ModalBody mx={2}>
+            <Stack spacing={2}>
               <FormControl>
-                <FormLabel>画像</FormLabel>
-                <Input value={food?.image} isReadOnly />
+                <Image src={food?.image} />
               </FormControl>
               <FormControl>
-                <FormLabel>商品名</FormLabel>
-                <Input value={food?.name} isReadOnly />
+                <Text fontSize="xl">{food?.name}</Text>
               </FormControl>
               <FormControl>
-                <FormLabel>商品説明</FormLabel>
-                <Input value={food?.food_description} isReadOnly />
+                <Text fontSize="xl">{food?.food_description}</Text>
               </FormControl>
               <FormControl>
-                <FormLabel>金額</FormLabel>
-                <Input value={food?.price} isReadOnly />
+                <Text fontSize="xl">金額 ¥ {food?.price.toLocaleString()}</Text>
               </FormControl>
             </Stack>
           </ModalBody>
+          <ModalFooter>
+            <CountDownButton
+              onClick={() => onClickDownCount()}
+              isDisabled={countNumber <= 1}
+            />
+            <Text fontSize="xl" p={4}>
+              {countNumber}
+            </Text>
+            <CountUpButton
+              onClick={() => onClickUpCount()}
+              isDisabled={countNumber >= 9}
+            />
+            <Spacer />
+            <OrderButton onClick={() => onClickOrder()}>
+              <Text p={2}>{`${countNumber}点をカートに追加 `}</Text>
+              <Text p={2}>{`¥${(
+                countNumber * food?.price
+              ).toLocaleString()}`}</Text>
+            </OrderButton>
+          </ModalFooter>
         </ModalContent>
       </ModalOverlay>
     </Modal>

--- a/frontend/src/components/pages/Foods.tsx
+++ b/frontend/src/components/pages/Foods.tsx
@@ -32,7 +32,9 @@ export const Foods: VFC = memo(() => {
   );
 
   // モーダルの注文個数用ステート
-  const [count, setCount] = useState(1);
+  const INITIAL_COUNT = 1;
+
+  const [count, setCount] = useState(INITIAL_COUNT);
 
   const onClickUpCount = () => setCount(count + 1);
 
@@ -41,7 +43,7 @@ export const Foods: VFC = memo(() => {
   const onClickOrder = () => alert();
 
   const onCloseFoodModal = () => {
-    setCount(1);
+    setCount(INITIAL_COUNT);
     onClose();
   };
 

--- a/frontend/src/components/pages/Foods.tsx
+++ b/frontend/src/components/pages/Foods.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable no-constant-condition */
-/* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable arrow-body-style */
 import { memo, useCallback, useEffect, VFC } from 'react';
 import { Center, Wrap, WrapItem } from '@chakra-ui/layout';
@@ -10,21 +9,26 @@ import { useDisclosure } from '@chakra-ui/hooks';
 import { useFoods } from 'hooks/useFoods';
 import { FoodCard } from 'components/organisms/food/FoodCard';
 import BeefTongue from 'images/BeefTongue.svg';
-import { FoodDetailModal } from 'components/organisms/food/FoodDetailModal';
+import { FoodOrderModal } from 'components/organisms/food/FoodOrderModal';
+import { useSelectFood } from 'hooks/useSelectFood';
 
 export const Foods: VFC = memo(() => {
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   const { getFoods, foods, loading } = useFoods();
 
+  const { onSelectFood, selectedFood } = useSelectFood();
+
   const { restaurantId } = useParams<{ restaurantId: string }>();
 
   useEffect(() => getFoods(restaurantId), []);
 
-  const onClickFood = useCallback((id: number) => {
-    console.log(id);
-    onOpen();
-  }, []);
+  const onClickFood = useCallback(
+    (id: number) => {
+      onSelectFood({ id, foods, onOpen });
+    },
+    [foods, onSelectFood, onOpen]
+  );
 
   return (
     <>
@@ -52,7 +56,7 @@ export const Foods: VFC = memo(() => {
           </Wrap>
         </div>
       )}
-      <FoodDetailModal isOpen={isOpen} onClose={onClose} />
+      <FoodOrderModal food={selectedFood} isOpen={isOpen} onClose={onClose} />
     </>
   );
 });

--- a/frontend/src/components/pages/Foods.tsx
+++ b/frontend/src/components/pages/Foods.tsx
@@ -10,14 +10,10 @@ import { useFoods } from 'hooks/useFoods';
 import { FoodCard } from 'components/organisms/food/FoodCard';
 import BeefTongue from 'images/BeefTongue.svg';
 
-type IdType = {
-  restaurantId: string;
-};
-
 export const Foods: VFC = memo(() => {
   const { getFoods, foods, loading } = useFoods();
 
-  const { restaurantId } = useParams<IdType>();
+  const { restaurantId } = useParams<{ restaurantId: string }>();
 
   useEffect(() => getFoods(restaurantId), []);
 

--- a/frontend/src/components/pages/Foods.tsx
+++ b/frontend/src/components/pages/Foods.tsx
@@ -1,21 +1,30 @@
 /* eslint-disable no-constant-condition */
 /* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable arrow-body-style */
-import { memo, useEffect, VFC } from 'react';
+import { memo, useCallback, useEffect, VFC } from 'react';
 import { Center, Wrap, WrapItem } from '@chakra-ui/layout';
 import { Spinner } from '@chakra-ui/spinner';
 import { useParams } from 'react-router-dom';
+import { useDisclosure } from '@chakra-ui/hooks';
 
 import { useFoods } from 'hooks/useFoods';
 import { FoodCard } from 'components/organisms/food/FoodCard';
 import BeefTongue from 'images/BeefTongue.svg';
+import { FoodDetailModal } from 'components/organisms/food/FoodDetailModal';
 
 export const Foods: VFC = memo(() => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
   const { getFoods, foods, loading } = useFoods();
 
   const { restaurantId } = useParams<{ restaurantId: string }>();
 
   useEffect(() => getFoods(restaurantId), []);
+
+  const onClickFood = useCallback((id: number) => {
+    console.log(id);
+    onOpen();
+  }, []);
 
   return (
     <>
@@ -31,16 +40,19 @@ export const Foods: VFC = memo(() => {
             {foods.map((food) => (
               <WrapItem key={food.id}>
                 <FoodCard
+                  id={food.id}
                   imageUrl={BeefTongue}
                   foodName={food.name}
                   foodDescription={food.food_description}
                   foodPrice={food.price}
+                  onClick={onClickFood}
                 />
               </WrapItem>
             ))}
           </Wrap>
         </div>
       )}
+      <FoodDetailModal isOpen={isOpen} onClose={onClose} />
     </>
   );
 });

--- a/frontend/src/components/pages/Foods.tsx
+++ b/frontend/src/components/pages/Foods.tsx
@@ -1,6 +1,7 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable no-constant-condition */
 /* eslint-disable arrow-body-style */
-import { memo, useCallback, useEffect, VFC } from 'react';
+import { memo, useCallback, useEffect, useState, VFC } from 'react';
 import { Center, Wrap, WrapItem } from '@chakra-ui/layout';
 import { Spinner } from '@chakra-ui/spinner';
 import { useParams } from 'react-router-dom';
@@ -30,6 +31,20 @@ export const Foods: VFC = memo(() => {
     [foods, onSelectFood, onOpen]
   );
 
+  // モーダルの注文個数用ステート
+  const [count, setCount] = useState(1);
+
+  const onClickUpCount = () => setCount(count + 1);
+
+  const onClickDownCount = () => setCount(count - 1);
+
+  const onClickOrder = () => alert();
+
+  const onCloseFoodModal = () => {
+    setCount(1);
+    onClose();
+  };
+
   return (
     <>
       {loading ? (
@@ -56,7 +71,15 @@ export const Foods: VFC = memo(() => {
           </Wrap>
         </div>
       )}
-      <FoodOrderModal food={selectedFood} isOpen={isOpen} onClose={onClose} />
+      <FoodOrderModal
+        food={selectedFood}
+        countNumber={count}
+        isOpen={isOpen}
+        onClose={onCloseFoodModal}
+        onClickUpCount={onClickUpCount}
+        onClickDownCount={onClickDownCount}
+        onClickOrder={onClickOrder}
+      />
     </>
   );
 });

--- a/frontend/src/components/pages/Foods.tsx
+++ b/frontend/src/components/pages/Foods.tsx
@@ -25,8 +25,8 @@ export const Foods: VFC = memo(() => {
   useEffect(() => getFoods(restaurantId), []);
 
   const onClickFood = useCallback(
-    (id: number) => {
-      onSelectFood({ id, foods, onOpen });
+    (selectFoodId: number) => {
+      onSelectFood({ selectFoodId, foods, onOpen });
     },
     [foods, onSelectFood, onOpen]
   );

--- a/frontend/src/components/pages/Foods.tsx
+++ b/frontend/src/components/pages/Foods.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable no-constant-condition */
 /* eslint-disable arrow-body-style */
 import { memo, useCallback, useEffect, useState, VFC } from 'react';
-import { Center, Wrap, WrapItem } from '@chakra-ui/layout';
+import { Center, Heading, Wrap, WrapItem } from '@chakra-ui/layout';
 import { Spinner } from '@chakra-ui/spinner';
 import { useParams } from 'react-router-dom';
 import { useDisclosure } from '@chakra-ui/hooks';
@@ -52,9 +52,8 @@ export const Foods: VFC = memo(() => {
           <Spinner />
         </Center>
       ) : (
-        // 挙動確認用のdivタグを追加（Foodモーダル実装時にdivタグとレストランIDは削除）
-        <div>
-          レストラン：{restaurantId}
+        <Wrap>
+          <Heading> レストラン：{restaurantId}</Heading>
           <Wrap p={{ base: 4, md: 10 }} justify="space-around">
             {foods.map((food) => (
               <WrapItem key={food.id}>
@@ -69,7 +68,7 @@ export const Foods: VFC = memo(() => {
               </WrapItem>
             ))}
           </Wrap>
-        </div>
+        </Wrap>
       )}
       <FoodOrderModal
         food={selectedFood}

--- a/frontend/src/hooks/useSelectFood.ts
+++ b/frontend/src/hooks/useSelectFood.ts
@@ -6,15 +6,18 @@ import { Food } from 'types/api/food';
 type Props = {
   id: number;
   foods: Array<Food>;
+  onOpen: () => void;
 };
 
+// 選択したフード情報を特定しモーダルを表示するカスタムフック
 export const useSelectFood = () => {
   const [selectedFood, setSelectedFood] = useState<Food | null>(null);
 
   const onSelectFood = useCallback((props: Props) => {
-    const { id, foods } = props;
+    const { id, foods, onOpen } = props;
     const targetFood = foods.find((food) => food.id === id);
     setSelectedFood(targetFood);
+    onOpen();
   }, []);
 
   return { onSelectFood, selectedFood };

--- a/frontend/src/hooks/useSelectFood.ts
+++ b/frontend/src/hooks/useSelectFood.ts
@@ -15,8 +15,8 @@ export const useSelectFood = () => {
 
   const onSelectFood = useCallback((props: Props) => {
     const { selectFoodId, foods, onOpen } = props;
-    const targetFood = foods.find((food) => food.id === selectFoodId);
-    setSelectedFood(targetFood);
+    const getSelectFood = foods.find((food) => food.id === selectFoodId);
+    setSelectedFood(getSelectFood);
     onOpen();
   }, []);
 

--- a/frontend/src/hooks/useSelectFood.ts
+++ b/frontend/src/hooks/useSelectFood.ts
@@ -1,0 +1,21 @@
+/* eslint-disable arrow-body-style */
+import { useCallback, useState } from 'react';
+
+import { Food } from 'types/api/food';
+
+type Props = {
+  id: number;
+  foods: Array<Food>;
+};
+
+export const useSelectFood = () => {
+  const [selectedFood, setSelectedFood] = useState<Food | null>(null);
+
+  const onSelectFood = useCallback((props: Props) => {
+    const { id, foods } = props;
+    const targetFood = foods.find((food) => food.id === id);
+    setSelectedFood(targetFood);
+  }, []);
+
+  return { onSelectFood, selectedFood };
+};

--- a/frontend/src/hooks/useSelectFood.ts
+++ b/frontend/src/hooks/useSelectFood.ts
@@ -4,7 +4,7 @@ import { useCallback, useState } from 'react';
 import { Food } from 'types/api/food';
 
 type Props = {
-  id: number;
+  selectFoodId: number;
   foods: Array<Food>;
   onOpen: () => void;
 };
@@ -14,8 +14,8 @@ export const useSelectFood = () => {
   const [selectedFood, setSelectedFood] = useState<Food | null>(null);
 
   const onSelectFood = useCallback((props: Props) => {
-    const { id, foods, onOpen } = props;
-    const targetFood = foods.find((food) => food.id === id);
+    const { selectFoodId, foods, onOpen } = props;
+    const targetFood = foods.find((food) => food.id === selectFoodId);
     setSelectedFood(targetFood);
     onOpen();
   }, []);


### PR DESCRIPTION
## issue
close #37 

## 実装の目的と概要
- フードカードをクリックした際、モーダルを表示し、選択したフード個数を表示する

## 実装内容
- フードカード選択時のモーダル表示機能
  - `FoodOrderModal`を作成し、モーダルのレイアウトを定義
  - `FoodCard`に`onClick`を追加し、カードクリックを起点とする機能を実装
  - 上記に連動して`Foods`内に`FoodOrderModel`を追加し、モーダル表示機能を実装
  - 選択したフードを特定し、モーダルを表示するカスタムフック`useSelectFood.ts`を作成し、`Foods`ページ内にて使用

- モーダル内の機能
  - 注文個数カウントに必要なボタン`CountDownButton/CountUpButton/OrderButton `を作成
  - `Foods`に`useState`を追加し、モーダル内の注文個数をカウント・保持する機能を実装
  - モーダルレイアウト（サイズ、ボタン位置、金額表示を調整）
  - 注文個数は1~9個までに限定（0個以下と10個以上は選択できない）
  - モーダルを一度閉じると、前回の注文個数はリセットされる
  - カートに追加ボタンはアラート表示のみ
 
## 画像

https://user-images.githubusercontent.com/42578729/144344215-08a6c651-a923-4f15-90cb-4c8f5c4c44ff.mov


## 今後の学習課題や記録しておくこと
- カートに追加ボタンの機能はカート機能で実装予定 #41 

## チェックリスト
- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか