### PR TITLE
[フロント]Headerにログイン名を表示

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -30,8 +30,8 @@
     "react/react-in-jsx-scope": 0,
     "react/jsx-uses-react": 0,
     "react/prop-types": 0,
-    "react/display-name": 0,
-    "no-console": 1
+    "react/display-name": 0
+    // "no-console": 1
   }
   // "overrides": [
   //   {

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -31,7 +31,6 @@
     "react/jsx-uses-react": 0,
     "react/prop-types": 0,
     "react/display-name": 0
-    // "no-console": 1
   }
   // "overrides": [
   //   {

--- a/frontend/src/components/organisms/layout/Header.tsx
+++ b/frontend/src/components/organisms/layout/Header.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable arrow-body-style */
 import { memo, useCallback, VFC } from 'react';
-import { Box, Flex, Heading, Link } from '@chakra-ui/layout';
+import { Box, Flex, Heading, HStack, Link} from '@chakra-ui/layout';
 import { Image } from '@chakra-ui/image';
 import { useDisclosure } from '@chakra-ui/hooks';
 import { useHistory } from 'react-router-dom';
@@ -83,14 +83,21 @@ export const Header: VFC = memo(() => {
             <Link onClick={onClickLogin}>ゲストログイン</Link>
           </Box>
         </Flex>
-        <Box _hover={{ opacity: '0.8', cursor: 'pointer' }}>
-          <Image
-            boxSize="40px"
-            src={CartIcon}
-            alt="CartIcon"
-            onClick={onClickCart}
-          />
-        </Box>
+        <HStack spacing="24px">
+          {loginUser && (
+            <Box _hover={{ opacity: '0.8', cursor: 'pointer' }}>
+              {loginUser.name + `さん`}
+            </Box>
+          )}
+          <Box _hover={{ opacity: '0.8', cursor: 'pointer' }}>
+            <Image
+              boxSize="40px"
+              src={CartIcon}
+              alt="CartIcon"
+              onClick={onClickCart}
+            />
+          </Box>
+        </HStack>
       </Flex>
       <MenuDrawer
         onClose={onCloseMenuDrawer}

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -29,7 +29,6 @@ export const useAuth = () => {
             'Content-Type': 'application/json',
           },
         });
-
         const result = await res.json();
         setLoginUser(result.data);
         showMessage({ title: 'ログインしました', status: 'success' });
@@ -54,7 +53,7 @@ export const useAuth = () => {
   // ログアウト
   const logout = useCallback(async () => {
     try {
-      axios.delete(signOutUrl, {
+      await axios.delete(signOutUrl, {
         headers: {
           'access-token': Cookies.get('_access_token'),
           client: Cookies.get('_client'),

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -22,15 +22,25 @@ export const useAuth = () => {
     async (params: SignInParams) => {
       setLoading(true);
       try {
-        const res = await axios.post<User>(signInUrl, params);
-        setLoginUser(res.data);
+        const res = await fetch(signInUrl, {
+          method: 'POST',
+          body: JSON.stringify(params),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+
+        const result = await res.json();
+        setLoginUser(result.data);
         showMessage({ title: 'ログインしました', status: 'success' });
-        // ログインに成功した場合はCookieに各値を格納
-        Cookies.set('_access_token', res.headers['access-token']);
-        Cookies.set('_client', res.headers['client']);
-        Cookies.set('_uid', res.headers['uid']);
+        // TODO:access-tokenに保持するのは良くないので、サーバーサイドでsession.idを付与する方式に移行するまでの暫定
+        const res2 = await axios.post<User>(signInUrl, params);
+        Cookies.set('_access_token', res2.headers['access-token']);
+        Cookies.set('_client', res2.headers['client']);
+        Cookies.set('_uid', res2.headers['uid']);
         history.push('/restaurants');
       } catch (e) {
+        alert(e);
         showMessage({
           title: 'ユーザID、パスワードの入力に誤りがあるか登録されていません。',
           status: 'error',

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "module": "esnext",
     "lib": ["es2020", "dom"],
     "jsx": "react-jsx",


### PR DESCRIPTION
## issue
close #81 

## 実装の目的と概要
- `Header`にログイン名を表示

## 実装内容(技術的な点を記載)
- `Header`に表示欄を追加
- `fetch`を使用して、氏名を取得（sessionを使ったログイン機能に切り替えるまでの暫定）
 
## スクリーンショット（画面レイアウトを変更した場合）
### 画面名

![ログイン氏名表示](https://user-images.githubusercontent.com/42578729/151918560-4bb5ebf0-2aad-46e1-88e8-14d6e335c391.png)

## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] ローカル環境でrspecを実行してfailure, errorが出力されていないか(pendingはOK)
```
rspec spec/models
rspec spec/requests
```
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか

