### PR TITLE
[フロント]Headerのログイン／ログアウト表示を修正

### DIFF
--- a/frontend/src/components/organisms/layout/Header.tsx
+++ b/frontend/src/components/organisms/layout/Header.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable arrow-body-style */
 import { memo, useCallback, VFC } from 'react';
-import { Box, Flex, Heading, HStack, Link} from '@chakra-ui/layout';
+import { Box, Flex, Heading, HStack, Link } from '@chakra-ui/layout';
 import { Image } from '@chakra-ui/image';
 import { useDisclosure } from '@chakra-ui/hooks';
 import { useHistory } from 'react-router-dom';

--- a/frontend/src/hooks/useGetCurrentUser.ts
+++ b/frontend/src/hooks/useGetCurrentUser.ts
@@ -1,0 +1,28 @@
+import { useCallback } from 'react';
+import Cookies from 'js-cookie';
+
+export const useGetCurrentUser = () => {
+  // current_userを取得
+  const getCurrentUser = useCallback(async () => {
+    if (
+      !Cookies.get('_access_token') ||
+      !Cookies.get('_client') ||
+      !Cookies.get('_uid')
+    )
+      return;
+    const res = await fetch(
+      `${process.env.REACT_APP_SERVER_URL}/api/v1/auth/validate_token`,
+      {
+        method: 'GET',
+        headers: {
+          'access-token': Cookies.get('_access_token'),
+          client: Cookies.get('_client'),
+          uid: Cookies.get('_uid'),
+        },
+      }
+    );
+    const result = await res.json();
+    return result.data;
+  }, []);
+  return { getCurrentUser };
+};

--- a/frontend/src/providers/LoginUserProvider.tsx
+++ b/frontend/src/providers/LoginUserProvider.tsx
@@ -29,7 +29,6 @@ export const LoginUserProvider = (props: { children: ReactNode }) => {
     res
       .then(function (result) {
         if (loginUser === null) setLoginUser(result);
-        console.log(loginUser);
       })
       .catch(function (error) {
         console.log(error);

--- a/frontend/src/providers/LoginUserProvider.tsx
+++ b/frontend/src/providers/LoginUserProvider.tsx
@@ -3,10 +3,12 @@ import {
   Dispatch,
   ReactNode,
   SetStateAction,
+  useEffect,
   useState,
 } from 'react';
 
 import { User } from 'types/api/user';
+import { useGetCurrentUser } from 'hooks/useGetCurrentUser';
 
 export type LoginUserContextType = {
   loginUser: User | null;
@@ -20,6 +22,20 @@ export const LoginUserContext = createContext<LoginUserContextType>(
 export const LoginUserProvider = (props: { children: ReactNode }) => {
   const { children } = props;
   const [loginUser, setLoginUser] = useState<User | null>(null);
+  const { getCurrentUser } = useGetCurrentUser();
+
+  useEffect(() => {
+    const res = getCurrentUser();
+    res
+      .then(function (result) {
+        if (loginUser === null) setLoginUser(result);
+        console.log(loginUser);
+      })
+      .catch(function (error) {
+        console.log(error);
+      });
+  }, [getCurrentUser, loginUser]);
+
   return (
     <LoginUserContext.Provider value={{ loginUser, setLoginUser }}>
       {children}


### PR DESCRIPTION
## issue
close #89 

## 実装の目的と概要
- ログインしている状態で、ブラウザ（chrome）をリロード（更新）すると、`Header`の「ログアウト」表示が、「ログイン」表示になる不具合を修正

## 実装内容(技術的な点を記載)
- `LoginUserProvider.tsx`に`useEffect`を実装
  - ブラウザがリロードされると、グローバルでステートしていた`loginUser`が`null`になるので、`useEffect`で依存する値`loginUser`が変更される度に`null`を判定し、`getCurrentUser`を`callback`させた
  - レスポンスされた`Promise`を`.then`で展開し、値を取得
- `useGetCurrentUser`を作成
  - `headers`情報でカレントユーザーを取得するパスを使用`/auth/validate_token`
  - `axios`がresponseの深い情報を取得できない不具合があるので、`fetch`を使用
 
## スクリーンショット（画面レイアウトを変更した場合）
### 画面名


https://user-images.githubusercontent.com/42578729/152307577-7fa4e4ea-7916-437d-a450-74abc2f38b02.mov



## 参考資料
- [プロミスの基本](https://naito-coding0322.hatenablog.com/entry/2019/01/11/163242)
- [hooks-effectの利用法](https://ja.reactjs.org/docs/hooks-effect.html)

## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] ローカル環境でrspecを実行してfailure, errorが出力されていないか(pendingはOK)
```
rspec spec/models
rspec spec/requests
```
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか

## 備考（実装していないことなど）
-  #91 は別タスク