### PR TITLE
[フロント]CartModal合計金額計算をフロントで完結する機能実装

### DIFF
--- a/frontend/src/components/organisms/cart/CartCard.tsx
+++ b/frontend/src/components/organisms/cart/CartCard.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable arrow-body-style */
-import { ChangeEvent, memo, useCallback, useState, VFC } from 'react';
+import { memo, useCallback, VFC } from 'react';
 import { HStack, Text, VStack } from '@chakra-ui/layout';
 import { Food } from 'types/api/cart';
 import { DeleteButton } from 'components/atoms/button/DeleteButton';
@@ -10,12 +10,11 @@ type Props = {
   foodName: string;
   count: number;
   price: number;
+  onChangeCount?: (newCount: number) => void;
 };
 
 export const CartCard: VFC<Props> = memo((props) => {
-  const { foodName, count, price } = props;
-
-  const [cartCount, setCartCount] = useState(count);
+  const { food, foodName, count, price, onChangeCount } = props;
 
   const onClickDelete = useCallback(
     () => alert('該当するカート詳細を削除します'),
@@ -27,10 +26,6 @@ export const CartCard: VFC<Props> = memo((props) => {
   const NUMBER_OF_LIMIT = 20;
 
   const lists = [...Array(NUMBER_OF_LIMIT).keys()].map((i) => ++i);
-
-  const handleChange = (ev: ChangeEvent<HTMLSelectElement>) => {
-    setCartCount(Number(ev.target.value));
-  };
 
   return (
     <HStack
@@ -52,9 +47,11 @@ export const CartCard: VFC<Props> = memo((props) => {
           rounded={'full'}
           color={'brand'}
           fontWeight={'bold'}
-          value={cartCount}
+          value={count}
           id={'count'}
-          onChange={handleChange}
+          onChange={(e) =>
+            onChangeCount && onChangeCount(Number(e.target.value))
+          }
         >
           {lists.map((list, i) => (
             <option key={i} value={list}>
@@ -74,7 +71,7 @@ export const CartCard: VFC<Props> = memo((props) => {
           {foodName}
         </Text>
         <Text w={'64'} textAlign={'center'} fontSize={'xl'} fontWeight="bold">
-          ¥ {(price * cartCount).toLocaleString()}
+          ¥ {(price * count).toLocaleString()}
         </Text>
       </VStack>
     </HStack>

--- a/frontend/src/components/organisms/cart/CartCard.tsx
+++ b/frontend/src/components/organisms/cart/CartCard.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable arrow-body-style */
 import { memo, useCallback, VFC } from 'react';
 import { HStack, Text, VStack } from '@chakra-ui/layout';
-import { Food } from 'types/api/cart';
+import { Food } from 'types/api/food';
 import { DeleteButton } from 'components/atoms/button/DeleteButton';
 import { Select } from '@chakra-ui/react';
 

--- a/frontend/src/components/organisms/cart/CartModal.tsx
+++ b/frontend/src/components/organisms/cart/CartModal.tsx
@@ -41,12 +41,8 @@ type Items = {
 
 export const CartModal: VFC<Props> = memo((props) => {
   const { isOpen, onClose } = props;
-  const { getCarts, carts, loading } = useCartIndex();
+  const { carts, loading } = useCartIndex();
   const [items, setItems] = useState<Items>([]);
-
-  useEffect(() => {
-    getCarts();
-  }, []);
 
   useEffect(() => {
     setItems(

--- a/frontend/src/components/organisms/cart/CartModal.tsx
+++ b/frontend/src/components/organisms/cart/CartModal.tsx
@@ -22,30 +22,21 @@ import { Spinner } from '@chakra-ui/react';
 
 import { useCartIndex } from 'hooks/useCartIndex';
 import { CartCard } from './CartCard';
+import { NewCarts } from 'types/api/newCarts';
 import { CartButton } from 'components/atoms/button/CartButton';
-import { Food } from 'types/api/food';
 
 type Props = {
   isOpen: boolean;
   onClose: () => void;
 };
 
-type Items = {
-  id: number;
-  amount: number;
-  count: number;
-  name: string;
-  price: number;
-  food: Food;
-}[];
-
 export const CartModal: VFC<Props> = memo((props) => {
   const { isOpen, onClose } = props;
   const { carts, loading } = useCartIndex();
-  const [items, setItems] = useState<Items>([]);
+  const [newCarts, setNewCarts] = useState<NewCarts>([]);
 
   useEffect(() => {
-    setItems(
+    setNewCarts(
       carts.map((cart) => ({
         id: cart.food.id,
         amount: cart.count * cart.food.price,
@@ -65,7 +56,10 @@ export const CartModal: VFC<Props> = memo((props) => {
 
   // Calculate the total amount
 
-  const totalAmount = items.reduce((total, item) => total + item.amount, 0);
+  const totalAmount = newCarts.reduce(
+    (total, newCart) => total + newCart.amount,
+    0
+  );
 
   return (
     <>
@@ -93,9 +87,9 @@ export const CartModal: VFC<Props> = memo((props) => {
                 </Center>
               ) : (
                 <Wrap p={{ base: 4, md: 10 }} justify="space-around">
-                  {items ? (
+                  {newCarts ? (
                     <>
-                      {items.map((cart, i) => (
+                      {newCarts.map((cart, i) => (
                         <WrapItem key={i}>
                           <CartCard
                             food={cart.food}
@@ -103,11 +97,12 @@ export const CartModal: VFC<Props> = memo((props) => {
                             count={cart.count}
                             price={cart.price}
                             onChangeCount={(newCount) => {
-                              setItems((s) =>
-                                s.map((item) => {
-                                  if (item.id !== cart.food.id) return item;
+                              setNewCarts((s) =>
+                                s.map((newCart) => {
+                                  if (newCart.id !== cart.food.id)
+                                    return newCart;
                                   return {
-                                    ...item,
+                                    ...newCart,
                                     amount: cart.food.price * newCount,
                                     count: newCount,
                                   };

--- a/frontend/src/components/pages/Cart.tsx
+++ b/frontend/src/components/pages/Cart.tsx
@@ -9,11 +9,7 @@ import { CartCard } from 'components/organisms/cart/CartCard';
 import { useCartIndex } from 'hooks/useCartIndex';
 
 export const Cart: VFC = memo(() => {
-  const { getCarts, carts, loading } = useCartIndex();
-
-  useEffect(() => {
-    getCarts();
-  }, []);
+  const { carts, loading } = useCartIndex();
 
   const onClickOrderButton = useCallback(() => {
     alert('stripe決済ページを飛ばして受取票ページへ遷移');

--- a/frontend/src/components/pages/Cart.tsx
+++ b/frontend/src/components/pages/Cart.tsx
@@ -1,15 +1,30 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable arrow-body-style */
-import { memo, useCallback, useEffect, VFC } from 'react';
+import { memo, useCallback, useEffect, useState, VFC } from 'react';
 import { Box, Center, Text, VStack, Wrap, WrapItem } from '@chakra-ui/layout';
 import { Spinner } from '@chakra-ui/spinner';
 
 import { CartButton } from 'components/atoms/button/CartButton';
 import { CartCard } from 'components/organisms/cart/CartCard';
 import { useCartIndex } from 'hooks/useCartIndex';
+import { NewCarts } from 'types/api/newCarts';
 
 export const Cart: VFC = memo(() => {
   const { carts, loading } = useCartIndex();
+  const [newCarts, setNewCarts] = useState<NewCarts>([]);
+
+  useEffect(() => {
+    setNewCarts(
+      carts.map((cart) => ({
+        id: cart.food.id,
+        amount: cart.count * cart.food.price,
+        count: cart.count,
+        name: cart.food.name,
+        price: cart.food.price,
+        food: cart.food,
+      }))
+    );
+  }, [carts]);
 
   const onClickOrderButton = useCallback(() => {
     alert('stripe決済ページを飛ばして受取票ページへ遷移');
@@ -17,9 +32,10 @@ export const Cart: VFC = memo(() => {
 
   // Calculate the total amount
 
-  let totalAmount = 0;
-
-  carts.map((cart) => (totalAmount += cart.count * cart.food.price));
+  const totalAmount = newCarts.reduce(
+    (total, newCart) => total + newCart.amount,
+    0
+  );
 
   return (
     <>
@@ -33,16 +49,28 @@ export const Cart: VFC = memo(() => {
             カートページ
           </Box>
           <Wrap p={{ base: 4, md: 10 }}>
-            {carts ? (
+            {newCarts ? (
               <>
                 <VStack>
-                  {carts.map((cart, i) => (
+                  {newCarts.map((cart, i) => (
                     <WrapItem key={i}>
                       <CartCard
                         food={cart.food}
                         foodName={cart.food.name}
                         count={cart.count}
-                        price={cart.food.price}
+                        price={cart.price}
+                        onChangeCount={(newCount) => {
+                          setNewCarts((s) =>
+                            s.map((newCart) => {
+                              if (newCart.id !== cart.food.id) return newCart;
+                              return {
+                                ...newCart,
+                                amount: cart.food.price * newCount,
+                                count: newCount,
+                              };
+                            })
+                          );
+                        }}
                       />
                     </WrapItem>
                   ))}

--- a/frontend/src/hooks/useCartIndex.ts
+++ b/frontend/src/hooks/useCartIndex.ts
@@ -2,7 +2,7 @@
 /* eslint-disable arrow-body-style */
 import axios from 'axios';
 import Cookies from 'js-cookie';
-import { useCallback, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Cart } from 'types/api/cart';
 
 import { cartsUrl } from '../url';
@@ -13,26 +13,28 @@ export const useCartIndex = () => {
   const [loading, setLoading] = useState(false);
   const [carts, setCarts] = useState<Array<Cart>>([]);
 
-  const getCarts = useCallback(async () => {
-    setLoading(true);
-    try {
-      const result = await axios.get<Array<Cart>>(cartsUrl, {
-        headers: {
-          'access-token': Cookies.get('_access_token'),
-          client: Cookies.get('_client'),
-          uid: Cookies.get('_uid'),
-        },
-      });
-      setCarts(result.data);
-    } catch (e) {
-      showMessage({
-        title: 'データの取得に失敗しました',
-        status: 'error',
-      });
-    } finally {
-      setLoading(false);
-    }
+  useEffect(() => {
+    const fetchCarts = async () => {
+      setLoading(true);
+      try {
+        const result = await axios.get<Array<Cart>>(cartsUrl, {
+          headers: {
+            'access-token': Cookies.get('_access_token'),
+            client: Cookies.get('_client'),
+            uid: Cookies.get('_uid'),
+          },
+        });
+        setCarts(result.data);
+      } catch (e) {
+        showMessage({
+          title: 'データの取得に失敗しました',
+          status: 'error',
+        });
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchCarts();
   }, []);
-
-  return { getCarts, loading, carts };
+  return { carts, loading };
 };

--- a/frontend/src/types/api/cart.ts
+++ b/frontend/src/types/api/cart.ts
@@ -1,15 +1,4 @@
-export type Food = {
-  id: number;
-  restaurant_id: number;
-  name: string;
-  food_description: string;
-  price: number;
-  sales_limit?: number;
-  sales_status?: string;
-  image?: string;
-  created_at: string;
-  updated_at: string;
-};
+import { Food } from './food';
 
 export type Cart = {
   id: number;

--- a/frontend/src/types/api/food.ts
+++ b/frontend/src/types/api/food.ts
@@ -4,9 +4,9 @@ export type Food = {
   name: string;
   food_description: string;
   price: number;
-  sales_limit: number;
-  sales_status: string;
-  image: string;
+  sales_limit?: number;
+  sales_status?: string;
+  image?: string;
   created_at: string;
   updated_at: string;
 };

--- a/frontend/src/types/api/newCarts.ts
+++ b/frontend/src/types/api/newCarts.ts
@@ -1,0 +1,10 @@
+import { Food } from './food';
+
+export type NewCarts = {
+  id: number;
+  amount: number;
+  count: number;
+  name: string;
+  price: number;
+  food: Food;
+}[];


### PR DESCRIPTION
## issue
close #78 

## 実装の目的と概要
- `CartModal` と `CartPage` の合計金額計算をフロントで完結する機能を実装
 
## スクリーンショット（画面レイアウトを変更した場合）
### 画面名[カートモーダルの合計金額計算]


https://user-images.githubusercontent.com/42578729/155557958-16b3953f-dd3d-42be-81ba-618750468c25.mov

### 画面名[カートページの合計金額計算]


https://user-images.githubusercontent.com/42578729/155558118-3a20cdb3-015c-42c6-a8dc-5f51d298e0e5.mov


## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] ローカル環境でrspecを実行してfailure, errorが出力されていないか(pendingはOK)
```
rspec spec/models
rspec spec/requests
```
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか

## 自分用メモとして記録（技術的な実装内容）
- `CartCard.tsx` 
  - `props` で受け渡すのみに修正
  - `change event` で発火
- `CartModal.tsx` 
  -  `NewCarts` のステートを作成
  - `useEffect` でDBから取得した `carts` を `setNewCarts` にステートする
  -  `onChangeCount` でイベント発火により、新たに取得した `newCount` から、変更があった個数と合計金額だけ上書きすることで合計金額を更新
- `Cart.tsx` も同上
- `useCartIndex` リファクタリング  
  -  `useCartIndex` が呼び出されたら、レンダリングされるように、`useEffect` を移設

## 備考（実装していないことなど）
- #107 