### PR TITLE
[機能追加] `CartDetail` を削除する機能を実装

### DIFF
--- a/app/controllers/api/v1/carts_controller.rb
+++ b/app/controllers/api/v1/carts_controller.rb
@@ -47,6 +47,15 @@ module Api
       end
       # rubocop:enable all
 
+      def destroy
+        if current_api_v1_user.cart.cart_details.find_by(food_id: delete_params[:id]).destroy
+          cart_info = current_api_v1_user.cart.user_has_cart_info
+          render json: cart_info, status: :ok
+        else
+          render json: [], status: :no_content
+        end
+      end
+
       private
 
         def set_food
@@ -55,6 +64,10 @@ module Api
 
         def cart_details_params
           params.permit(:food_id, :count)
+        end
+
+        def delete_params
+          params.permit(:id)
         end
     end
   end

--- a/app/controllers/api/v1/carts_controller.rb
+++ b/app/controllers/api/v1/carts_controller.rb
@@ -3,9 +3,10 @@ module Api
     class CartsController < ApplicationController
       before_action :authenticate_api_v1_user!
       before_action :set_food, only: %i[create]
+      before_action :set_target_cart_detail, only: %i[destroy]
 
       def index
-        if current_api_v1_user.cart.present? && current_api_v1_user.cart.cart_details.present?
+        if current_api_v1_user.cart.present? && current_api_v1_user.cart_details.present?
           cart_info = current_api_v1_user.cart.user_has_cart_info
           render json: cart_info, status: :ok
         else
@@ -48,7 +49,8 @@ module Api
       # rubocop:enable all
 
       def destroy
-        if current_api_v1_user.cart.cart_details.find_by(food_id: delete_params[:id]).destroy
+        if @target_cart_detail
+          @target_cart_detail.destroy!
           cart_info = current_api_v1_user.cart.user_has_cart_info
           render json: cart_info, status: :ok
         else
@@ -60,6 +62,10 @@ module Api
 
         def set_food
           @ordered_food = Food.find(params[:food_id].to_i)
+        end
+
+        def set_target_cart_detail
+          @target_cart_detail = current_api_v1_user.cart_details.find_by(food_id: delete_params[:id])
         end
 
         def cart_details_params

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,7 @@ class User < ApplicationRecord
 
   has_one :cart,    dependent: :destroy
   has_many :orders, dependent: :destroy
+  has_many :cart_details, through: :cart, source: :cart_details
 
   validates :name,         presence: true
   validates :kana,         presence: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
         resources :foods, only: %i[index]
       end
 
-      resources :carts, only: %i[index create]
+      resources :carts, only: %i[index create destroy]
 
       put "carts/replace", to: "carts#replace"
 

--- a/frontend/src/components/organisms/cart/CartCard.tsx
+++ b/frontend/src/components/organisms/cart/CartCard.tsx
@@ -1,25 +1,20 @@
 /* eslint-disable arrow-body-style */
-import { memo, useCallback, VFC } from 'react';
+import { memo, VFC } from 'react';
 import { HStack, Text, VStack } from '@chakra-ui/layout';
-import { Food } from 'types/api/food';
 import { DeleteButton } from 'components/atoms/button/DeleteButton';
 import { Select } from '@chakra-ui/react';
 
 type Props = {
-  food: Food;
+  foodId: string;
   foodName: string;
   count: number;
   price: number;
+  onClick: (foodId: string) => void;
   onChangeCount?: (newCount: number) => void;
 };
 
 export const CartCard: VFC<Props> = memo((props) => {
-  const { food, foodName, count, price, onChangeCount } = props;
-
-  const onClickDelete = useCallback(
-    () => alert('該当するカート詳細を削除します'),
-    []
-  );
+  const { foodId, foodName, count, price, onClick, onChangeCount } = props;
 
   // Create a list of selections
 
@@ -37,7 +32,7 @@ export const CartCard: VFC<Props> = memo((props) => {
       _hover={{ cursor: 'pointer', opacity: 0.8 }}
     >
       <VStack>
-        <DeleteButton onClick={() => onClickDelete()}>削除</DeleteButton>
+        <DeleteButton onClick={() => onClick(foodId)}>削除</DeleteButton>
         <Select
           w={'20'}
           h={'8'}

--- a/frontend/src/components/organisms/cart/CartModal.tsx
+++ b/frontend/src/components/organisms/cart/CartModal.tsx
@@ -24,6 +24,7 @@ import { useCartIndex } from 'hooks/useCartIndex';
 import { CartCard } from './CartCard';
 import { NewCarts } from 'types/api/newCarts';
 import { CartButton } from 'components/atoms/button/CartButton';
+import { useDeleteCartDetails } from 'hooks/useDeleteCartDetails';
 
 type Props = {
   isOpen: boolean;
@@ -36,16 +37,17 @@ export const CartModal: VFC<Props> = memo((props) => {
   const [newCarts, setNewCarts] = useState<NewCarts>([]);
 
   useEffect(() => {
-    setNewCarts(
-      carts.map((cart) => ({
-        id: cart.food.id,
-        amount: cart.count * cart.food.price,
-        count: cart.count,
-        name: cart.food.name,
-        price: cart.food.price,
-        food: cart.food,
-      }))
-    );
+    if (carts.length)
+      setNewCarts(
+        carts.map((cart) => ({
+          id: cart.food.id,
+          amount: cart.count * cart.food.price,
+          count: cart.count,
+          name: cart.food.name,
+          price: cart.food.price,
+          food: cart.food,
+        }))
+      );
   }, [carts]);
 
   const history = useHistory();
@@ -60,6 +62,23 @@ export const CartModal: VFC<Props> = memo((props) => {
     (total, newCart) => total + newCart.amount,
     0
   );
+
+  const { deleteCartDetails } = useDeleteCartDetails();
+
+  const onClickDelete = useCallback((foodId: string) => {
+    deleteCartDetails(foodId);
+    if (carts.length)
+      setNewCarts(
+        carts.map((cart) => ({
+          id: cart.food.id,
+          amount: cart.count * cart.food.price,
+          count: cart.count,
+          name: cart.food.name,
+          price: cart.food.price,
+          food: cart.food,
+        }))
+      );
+  }, []);
 
   return (
     <>
@@ -87,15 +106,16 @@ export const CartModal: VFC<Props> = memo((props) => {
                 </Center>
               ) : (
                 <Wrap p={{ base: 4, md: 10 }} justify="space-around">
-                  {newCarts ? (
+                  {newCarts.length ? (
                     <>
                       {newCarts.map((cart, i) => (
                         <WrapItem key={i}>
                           <CartCard
-                            food={cart.food}
+                            foodId={String(cart.food.id)}
                             foodName={cart.food.name}
                             count={cart.count}
                             price={cart.price}
+                            onClick={() => onClickDelete(String(cart.food.id))}
                             onChangeCount={(newCount) => {
                               setNewCarts((s) =>
                                 s.map((newCart) => {
@@ -114,7 +134,7 @@ export const CartModal: VFC<Props> = memo((props) => {
                       ))}
                     </>
                   ) : (
-                    <p>カートはありません</p>
+                    <p>カートの中に商品はありません</p>
                   )}
                 </Wrap>
               )}

--- a/frontend/src/components/pages/Cart.tsx
+++ b/frontend/src/components/pages/Cart.tsx
@@ -8,22 +8,24 @@ import { CartButton } from 'components/atoms/button/CartButton';
 import { CartCard } from 'components/organisms/cart/CartCard';
 import { useCartIndex } from 'hooks/useCartIndex';
 import { NewCarts } from 'types/api/newCarts';
+import { useDeleteCartDetails } from 'hooks/useDeleteCartDetails';
 
 export const Cart: VFC = memo(() => {
   const { carts, loading } = useCartIndex();
   const [newCarts, setNewCarts] = useState<NewCarts>([]);
 
   useEffect(() => {
-    setNewCarts(
-      carts.map((cart) => ({
-        id: cart.food.id,
-        amount: cart.count * cart.food.price,
-        count: cart.count,
-        name: cart.food.name,
-        price: cart.food.price,
-        food: cart.food,
-      }))
-    );
+    if (carts.length)
+      setNewCarts(
+        carts.map((cart) => ({
+          id: cart.food.id,
+          amount: cart.count * cart.food.price,
+          count: cart.count,
+          name: cart.food.name,
+          price: cart.food.price,
+          food: cart.food,
+        }))
+      );
   }, [carts]);
 
   const onClickOrderButton = useCallback(() => {
@@ -37,6 +39,23 @@ export const Cart: VFC = memo(() => {
     0
   );
 
+  const { deleteCartDetails } = useDeleteCartDetails();
+
+  const onClickDelete = useCallback((foodId: string) => {
+    deleteCartDetails(foodId);
+    if (carts.length)
+      setNewCarts(
+        carts.map((cart) => ({
+          id: cart.food.id,
+          amount: cart.count * cart.food.price,
+          count: cart.count,
+          name: cart.food.name,
+          price: cart.food.price,
+          food: cart.food,
+        }))
+      );
+  }, []);
+
   return (
     <>
       {loading ? (
@@ -49,16 +68,19 @@ export const Cart: VFC = memo(() => {
             カートページ
           </Box>
           <Wrap p={{ base: 4, md: 10 }}>
-            {newCarts ? (
+            {newCarts.length ? (
               <>
                 <VStack>
                   {newCarts.map((cart, i) => (
                     <WrapItem key={i}>
                       <CartCard
-                        food={cart.food}
+                        foodId={String(cart.food.id)}
                         foodName={cart.food.name}
                         count={cart.count}
                         price={cart.price}
+                        onClick={() => {
+                          onClickDelete(String(cart.food.id));
+                        }}
                         onChangeCount={(newCount) => {
                           setNewCarts((s) =>
                             s.map((newCart) => {
@@ -77,7 +99,7 @@ export const Cart: VFC = memo(() => {
                 </VStack>
               </>
             ) : (
-              <p>カートはありません</p>
+              <p>カートの中に商品はありません</p>
             )}
           </Wrap>
           <VStack w={'full'} h="30vh">

--- a/frontend/src/hooks/useDeleteCartDetails.ts
+++ b/frontend/src/hooks/useDeleteCartDetails.ts
@@ -1,0 +1,41 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+/* eslint-disable arrow-body-style */
+import axios from 'axios';
+import Cookies from 'js-cookie';
+import { useCallback, useState } from 'react';
+
+import { Cart } from 'types/api/cart';
+import { cartDeleteUrl } from '../url';
+import { useMessage } from './useMessage';
+
+export const useDeleteCartDetails = () => {
+  const { showMessage } = useMessage();
+  const [loading, setLoading] = useState(false);
+  const [carts, setCarts] = useState<Array<Cart>>();
+
+  const deleteCartDetails = useCallback(async (foodId: string) => {
+    setLoading(true);
+    try {
+      const result = await axios.delete<Array<Cart>>(cartDeleteUrl(foodId), {
+        headers: {
+          'access-token': Cookies.get('_access_token'),
+          client: Cookies.get('_client'),
+          uid: Cookies.get('_uid'),
+        },
+      });
+      setCarts(result.data);
+      showMessage({
+        title: 'フードを削除しました',
+        status: 'success',
+      });
+    } catch (e) {
+      showMessage({
+        title: 'フードを削除できませんでした',
+        status: 'error',
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+  return { deleteCartDetails, carts, loading };
+};

--- a/frontend/src/url.ts
+++ b/frontend/src/url.ts
@@ -14,6 +14,9 @@ export const foodsIndexUrl = (restaurantId: string) =>
 
 export const cartsUrl = `${DEFAULT_API_LOCALHOST}/carts`;
 
+export const cartDeleteUrl = (foodId: string) =>
+  `${DEFAULT_API_LOCALHOST}/carts/${foodId}`;
+
 export const cartsReplaceUrl = `${DEFAULT_API_LOCALHOST}/carts/replace`;
 
 export const orders = `${DEFAULT_API_LOCALHOST}/orders`;

--- a/spec/requests/api/v1/carts_spec.rb
+++ b/spec/requests/api/v1/carts_spec.rb
@@ -139,4 +139,42 @@ RSpec.describe "Api::V1::Carts", type: :request do
       end
     end
   end
+
+  describe "DELETE #destroy" do
+    let(:delete_params) { @cart_details.food }
+
+    context "トークン認証情報がある場合" do
+      subject { delete(api_v1_cart_path(delete_params), headers: headers) }
+
+      context "カートが存在する場合 && 商品が存在する場合" do
+        before {
+          @cart = create(:cart, user_id: current_user.id)
+          @cart_details = create(:cart_detail, cart_id: current_user.cart.id)
+        }
+
+        it "ok(200)がレスポンスされる" do
+          subject
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "カート詳細情報が削除されること" do
+          expect { subject }.to change { CartDetail.count }.by(-1)
+        end
+      end
+    end
+
+    context "トークン認証情報がない場合" do
+      subject { delete(api_v1_cart_path(delete_params)) }
+
+      before {
+        @cart = create(:cart, user_id: current_user.id)
+        @cart_details = create(:cart_detail, cart_id: current_user.cart.id)
+      }
+
+      it "認証不可(401)がレスポンスされる" do
+        subject
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/carts_spec.rb
+++ b/spec/requests/api/v1/carts_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe "Api::V1::Carts", type: :request do
 
       context "カートが存在する場合 && 商品が存在する場合" do
         before {
-          @cart = create(:cart, user_id: current_user.id)
+          create(:cart, user_id: current_user.id)
           @cart_details = create(:cart_detail, cart_id: current_user.cart.id)
         }
 
@@ -161,13 +161,25 @@ RSpec.describe "Api::V1::Carts", type: :request do
           expect { subject }.to change { CartDetail.count }.by(-1)
         end
       end
+
+      context "カートが存在する場合 && 商品が存在しない場合" do
+        let(:delete_params) { @food }
+        before {
+          create(:cart, user_id: current_user.id)
+          @food = create(:food)
+        }
+
+        it "カート詳細情報は削除できない" do
+          expect { subject }.to change { CartDetail.count }.by(0)
+        end
+      end
     end
 
     context "トークン認証情報がない場合" do
       subject { delete(api_v1_cart_path(delete_params)) }
 
       before {
-        @cart = create(:cart, user_id: current_user.id)
+        create(:cart, user_id: current_user.id)
         @cart_details = create(:cart_detail, cart_id: current_user.cart.id)
       }
 


### PR DESCRIPTION
## issue
close #107 

## 実装の目的と概要
- `CartDetail` を削除する機能を実装

## 実装内容(技術的な点を記載)
- `CartModal` 内の `削除` を押すと `CartDetail` が削除される
-  `carts_controller` に `destroy` メソッド実装
- テスト実装 `destroy`
 
## 画面
※現在フロントではリロードしなければ動作しないので、画面はなし

## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] ローカル環境でrspecを実行してfailure, errorが出力されていないか(pendingはOK)
```
rspec spec/models
rspec spec/requests
```
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか

## 備考（実装していないことなど）
- [ ] [機能追加] `CartDetail` の個数変更機能を実装
- [ ] [フロント] 削除・個数変更時のレンダリング機能を実装