### PR TITLE
[機能追加]ゲストログイン機能追加

### DIFF
--- a/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/app/controllers/api/v1/auth/sessions_controller.rb
@@ -9,6 +9,13 @@ module Api
             render json: { is_login: false, message: "ユーザーが存在しません" }
           end
         end
+
+        def guest_sign_in
+          @resource = User.guest
+          @token = @resource.create_token
+          @resource.save!
+          render_create_success
+        end
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,4 +26,14 @@ class User < ApplicationRecord
     active: 0,
     supended: 1,
   }
+
+  # ゲストユーザーが存在しない場合、ゲストユーザーを作成
+  def self.guest
+    find_or_create_by!(email: "guest@example.com") do |user|
+      user.password = SecureRandom.urlsafe_base64
+      user.name = "ゲストユーザー"
+      user.kana = "ゲストユーザー"
+      user.phone_number = "00012345678"
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
+      devise_scope :api_v1_user do
+        post "auth/guest_sign_in", to: "auth/sessions#guest_sign_in"
+      end
+
       mount_devise_token_auth_for "User", at: "auth", controllers: {
         registrations: "api/v1/auth/registrations",
       }

--- a/frontend/src/components/atoms/button/GuestButton.tsx
+++ b/frontend/src/components/atoms/button/GuestButton.tsx
@@ -3,12 +3,20 @@ import { Button } from '@chakra-ui/button';
 
 type Props = {
   children: ReactNode;
+  loading?: boolean;
+  onClick: () => void;
 };
 
 export const GuestButton: VFC<Props> = memo((props) => {
-  const { children } = props;
+  const { children, loading = false, onClick } = props;
   return (
-    <Button bg="blue.400" color="white" _hover={{ opacity: 0.8 }}>
+    <Button
+      bg="blue.400"
+      color="white"
+      _hover={{ opacity: 0.8 }}
+      isLoading={loading}
+      onClick={onClick}
+    >
       {children}
     </Button>
   );

--- a/frontend/src/components/pages/Login.tsx
+++ b/frontend/src/components/pages/Login.tsx
@@ -19,10 +19,12 @@ import { useHistory } from 'react-router-dom';
 import { useAuth } from 'hooks/useAuth';
 import { SignInParams } from 'types/api/sign';
 import { useNewUserRegistration } from 'hooks/useNewUserRegistration';
+import { useGuestAuth } from 'hooks/useGuestAuth';
 
 export const Login: VFC = memo(() => {
   const { login, loading } = useAuth();
   const { newUserRegistrationLoading } = useNewUserRegistration();
+  const { guestLogin, loading: guestLoading } = useGuestAuth();
 
   const history = useHistory();
 
@@ -40,13 +42,14 @@ export const Login: VFC = memo(() => {
     email: userId,
     password: userPassword,
   };
-  const onClickLogin = () => login(params);
+  const onLogin = () => login(params);
 
-  const onClickNewUserRegistration = useCallback(
+  const onNewUserRegistration = useCallback(
     () => history.push('/new_user_registration'),
     [history]
   );
 
+  const onGuestLogin = () => guestLogin();
   return (
     <Flex bg="gray.200" align="center" justify="center" height="70vh">
       <Box bg="white" w="sm" p={4} borderRadius="md" shadow="md">
@@ -84,14 +87,16 @@ export const Login: VFC = memo(() => {
           <PrimaryButton
             disabled={!userId || !userPassword}
             loading={loading}
-            onClick={onClickLogin}
+            onClick={onLogin}
           >
             ログイン
           </PrimaryButton>
-          <GuestButton>ゲストログイン</GuestButton>
+          <GuestButton loading={guestLoading} onClick={onGuestLogin}>
+            ゲストログイン
+          </GuestButton>
           <NewUserRegistrationButton
             loading={newUserRegistrationLoading}
-            onClick={onClickNewUserRegistration}
+            onClick={onNewUserRegistration}
           >
             新規登録
           </NewUserRegistrationButton>

--- a/frontend/src/hooks/useGuestAuth.ts
+++ b/frontend/src/hooks/useGuestAuth.ts
@@ -26,12 +26,12 @@ export const useGuestAuth = () => {
           'Content-Type': 'application/json',
         },
       });
-      const result = await res.json();
-      setLoginUser(result.data);
-      const res2 = await axios.post<User>(guestSignInUrl);
-      Cookies.set('_access_token', res2.headers['access-token']);
-      Cookies.set('_client', res2.headers['client']);
-      Cookies.set('_uid', res2.headers['uid']);
+      const resForUserName = await res.json();
+      setLoginUser(resForUserName.data);
+      const resForCookies = await axios.post<User>(guestSignInUrl);
+      Cookies.set('_access_token', resForCookies.headers['access-token']);
+      Cookies.set('_client', resForCookies.headers['client']);
+      Cookies.set('_uid', resForCookies.headers['uid']);
       history.push('/');
       showMessage({ title: 'ゲストログインしました', status: 'success' });
     } catch (e) {

--- a/frontend/src/hooks/useGuestAuth.ts
+++ b/frontend/src/hooks/useGuestAuth.ts
@@ -1,0 +1,47 @@
+/* eslint-disable arrow-body-style */
+import axios from 'axios';
+import { useCallback, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import Cookies from 'js-cookie';
+
+import { User } from 'types/api/user';
+import { useMessage } from './useMessage';
+import { guestSignInUrl } from '../url';
+import { useLoginUser } from './useLoginUser';
+
+export const useGuestAuth = () => {
+  const history = useHistory();
+  const { showMessage } = useMessage();
+  const { setLoginUser } = useLoginUser();
+
+  const [loading, setLoading] = useState(false);
+
+  // ゲストログイン
+  const guestLogin = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(guestSignInUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+      const result = await res.json();
+      setLoginUser(result.data);
+      const res2 = await axios.post<User>(guestSignInUrl);
+      Cookies.set('_access_token', res2.headers['access-token']);
+      Cookies.set('_client', res2.headers['client']);
+      Cookies.set('_uid', res2.headers['uid']);
+      history.push('/');
+      showMessage({ title: 'ゲストログインしました', status: 'success' });
+    } catch (e) {
+      alert(e);
+      showMessage({
+        title: 'ゲストログインできませんでした',
+        status: 'error',
+      });
+      setLoading(false);
+    }
+  }, [history, showMessage, setLoginUser]);
+  return { guestLogin, loading };
+};

--- a/frontend/src/hooks/useGuestAuth.ts
+++ b/frontend/src/hooks/useGuestAuth.ts
@@ -35,7 +35,6 @@ export const useGuestAuth = () => {
       history.push('/');
       showMessage({ title: 'ゲストログインしました', status: 'success' });
     } catch (e) {
-      alert(e);
       showMessage({
         title: 'ゲストログインできませんでした',
         status: 'error',

--- a/frontend/src/url.ts
+++ b/frontend/src/url.ts
@@ -20,3 +20,5 @@ export const cartDetailsDeleteUrl = (foodId: string) =>
 export const cartsReplaceUrl = `${DEFAULT_API_LOCALHOST}/cart_details/replace`;
 
 export const orders = `${DEFAULT_API_LOCALHOST}/orders`;
+
+export const guestSignInUrl = `${DEFAULT_API_LOCALHOST}/auth/guest_sign_in`;

--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -64,4 +64,22 @@ RSpec.describe "Api::V1::Auth::Sessions", type: :request do
       end
     end
   end
+
+  # ゲストログイン
+  describe "POST /api/v1/auth/sessions/guest_sign_in" do
+    context "リクエストが送信された時" do
+      subject { post(api_v1_auth_guest_sign_in_path) }
+
+      it "ゲストログインできる" do
+        subject
+        expect(response).to have_http_status(:ok)
+        header = response.header
+        expect(header["access-token"]).to be_present
+        expect(header["client"]).to be_present
+        expect(header["expiry"]).to be_present
+        expect(header["uid"]).to be_present
+        expect(header["token-type"]).to be_present
+      end
+    end
+  end
 end


### PR DESCRIPTION
## issue
close #116 

## 実装の目的と概要
- ゲストログイン機能実装

## 実装内容(技術的な点を記載)
- バックエンド
  - ルーティング実装
  - コントローラーに `guest_sign_in` メソッド実装
  - モデルに `self.guest` クラスメソッド実装
  - テスト実装
- フロントエンド
  - `guestSignIn` url実装
  - ゲストボタン機能を追加 
 
## スクリーンショット
### 画面名　[ゲストログイン機能]

https://user-images.githubusercontent.com/42578729/160152964-b7a4cd9a-b858-4cfe-94cc-14259ebe07bf.mov


## 参考資料
- https://qiita.com/fumi238000/items/b119c0202f37e687c21c

## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] ローカル環境でrspecを実行してfailure, errorが出力されていないか(pendingはOK)
```
rspec spec/models
rspec spec/requests
```
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか

## 保留
- `fetch` と `axios` を一本にまとめられていない理由
  - `axios` の挙動がおかしいが `axios` を修正することができない： `console.log(res.data.name)` でユーザー名をコンソール上に表示することはできるが、データを取得し使用することはできない。 `res.data` までならデータを取得し使用することは可能。
  - `fetch` で `headers` を `Cookies` にセットすることができない：要学習 `fetch` `cors` `credentials` など