### PR TITLE
[フロント]受取票モーダル作成

### DIFF
--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -5,7 +5,7 @@ module Api
 
       def index
         if Order.check_users_order_history?(current_api_v1_user)
-          @orders = current_api_v1_user.orders
+          @orders = current_api_v1_user.orders.order(id: "DESC")
           render json: @orders, include: { order_details: [:food] }, status: :ok
         else
           render json: [], status: :no_content
@@ -14,9 +14,10 @@ module Api
 
       def create
         if Order.confirm_cart_presence?(order_params[:user_id].to_i) && Order.create_order_history(current_api_v1_user)
-          render status: :ok
+          @orders = current_api_v1_user.orders.last
+          render json: @orders, include: { order_details: [:food] }, status: :ok
         else
-          render status: :no_content
+          render json: [], status: :no_content
         end
       end
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -44,7 +44,7 @@ class Order < ApplicationRecord
   def self.order_create!(user)
     user.orders.create!(
       user_id: user.id,
-      rceipt_number: "#{Date.today.day} #{SecureRandom.alphanumeric(3)}", # rubocop:disable Rails/Date
+      rceipt_number: "#{Date.today.day} #{SecureRandom.alphanumeric(4)}", # rubocop:disable Rails/Date
       total_price: user.cart.total_price,
       consumption_tax: (BigDecimal(user.cart.total_price) * BigDecimal(ENV["CONSUMPTION_TAX"])).ceil,
       progress_status: "orde",

--- a/app/serializers/order_detail_serializer.rb
+++ b/app/serializers/order_detail_serializer.rb
@@ -1,0 +1,11 @@
+class OrderDetailSerializer < ActiveModel::Serializer
+  attributes :id, :count, :food_name, :food_price
+
+  def food_name
+    object.food.name
+  end
+
+  def food_price
+    object.food.price
+  end
+end

--- a/app/serializers/order_serializer.rb
+++ b/app/serializers/order_serializer.rb
@@ -5,16 +5,4 @@ class OrderSerializer < ActiveModel::Serializer
   def restaurant_name
     object.order_details.first.food.restaurant.name
   end
-
-  class OrderDetailSerializer < ActiveModel::Serializer
-    attributes :id, :count, :food_name, :food_price
-
-    def food_name
-      object.food.name
-    end
-
-    def food_price
-      object.food.price
-    end
-  end
 end

--- a/frontend/src/components/organisms/order/OrderCard.tsx
+++ b/frontend/src/components/organisms/order/OrderCard.tsx
@@ -10,37 +10,49 @@ import {
   WrapItem,
 } from '@chakra-ui/layout';
 import { OrderDetail } from 'types/api/orders';
+import { Button } from '@chakra-ui/react';
 
 type Props = {
   createdAt: string;
   restaurantName: string;
   totalPrice: number;
+  progressStatus: string;
+  receiptNumber: string;
   orderDetails: OrderDetail[];
 };
 
 export const OrderCard: VFC<Props> = memo((props) => {
-  const { createdAt, restaurantName, totalPrice, orderDetails } = props;
+  const {
+    createdAt,
+    restaurantName,
+    totalPrice,
+    progressStatus,
+    receiptNumber,
+    orderDetails,
+  } = props;
 
-  const dateTime = new Date(createdAt).toLocaleString();
+  const dateTime = new Date(createdAt).toLocaleDateString();
+
+  const onRecipt = () => {
+    alert(receiptNumber);
+  };
 
   return (
-    <Wrap justify={'center'}>
+    <Wrap>
       <VStack>
-        <HStack>
+        <HStack align={'start'}>
           <Box
-            w={{ sm: '122px', md: '180px' }}
+            w={{ sm: '80px', md: '120px' }}
             fontSize={{ sm: 'xs', md: 'lg' }}
             fontWeight={'bold'}
-            textAlign={'center'}
             isTruncated
           >
             {dateTime}
           </Box>
           <Box
-            w={{ sm: '122px', md: '180px' }}
+            w={{ sm: '80px', md: '140px' }}
             fontSize={{ sm: 'xs', md: 'lg' }}
             fontWeight={'bold'}
-            textAlign={'center'}
             isTruncated
           >
             {restaurantName}
@@ -50,10 +62,9 @@ export const OrderCard: VFC<Props> = memo((props) => {
               <WrapItem key={j}>
                 <HStack>
                   <Box
-                    w={{ sm: '94px', md: '140px' }}
+                    w={{ sm: '80px', md: '140px' }}
                     fontSize={{ sm: 'xs', md: 'lg' }}
                     fontWeight={'bold'}
-                    textAlign={'left'}
                     isTruncated
                   >
                     {detail.food_name}
@@ -75,7 +86,7 @@ export const OrderCard: VFC<Props> = memo((props) => {
             {orderDetails.map((detail, k) => (
               <WrapItem key={k}>
                 <Box
-                  w={{ sm: '122px', md: '180px' }}
+                  w={{ sm: '100px', md: '160px' }}
                   fontSize={{ sm: 'xs', md: 'lg' }}
                   fontWeight={'bold'}
                   textAlign={'right'}
@@ -85,18 +96,34 @@ export const OrderCard: VFC<Props> = memo((props) => {
                 </Box>
               </WrapItem>
             ))}
+            <Box
+              w={'100%'}
+              display={'flex'}
+              justifyContent={'right'}
+              alignItems="end"
+              fontSize={{ sm: 'xs', md: 'lg' }}
+              fontWeight={'bold'}
+            >
+              <Text>合計 ¥ {totalPrice.toLocaleString()}</Text>
+            </Box>
+          </VStack>
+          <VStack>
+            <Box
+              w={{ sm: '60px', md: '100px' }}
+              textAlign={'right'}
+              fontSize={{ sm: 'xs', md: 'lg' }}
+              fontWeight={'bold'}
+            >
+              {progressStatus === 'delivered' ? (
+                <Text>受取済</Text>
+              ) : (
+                <Button bg={'brand'} color={'white'} onClick={() => onRecipt()}>
+                  {receiptNumber}
+                </Button>
+              )}
+            </Box>
           </VStack>
         </HStack>
-        <Box
-          w={'100%'}
-          display={'flex'}
-          justifyContent={'right'}
-          alignItems="end"
-          fontSize={{ sm: 'xs', md: 'lg' }}
-          fontWeight={'bold'}
-        >
-          <Text>合計 ¥ {totalPrice.toLocaleString()}</Text>
-        </Box>
         <Divider borderColor={'brand'} border={'1px'} borderRadius={'lg'} />
       </VStack>
     </Wrap>

--- a/frontend/src/components/organisms/order/ReceiptModal.tsx
+++ b/frontend/src/components/organisms/order/ReceiptModal.tsx
@@ -1,0 +1,107 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+/* eslint-disable arrow-body-style */
+import { memo, VFC } from 'react';
+import { useHistory } from 'react-router-dom';
+import {
+  Box,
+  Center,
+  Spacer,
+  Text,
+  VStack,
+  Wrap,
+  WrapItem,
+} from '@chakra-ui/layout';
+import {
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalOverlay,
+} from '@chakra-ui/modal';
+import { Spinner } from '@chakra-ui/react';
+import { Orders } from 'types/api/orders';
+
+type Props = {
+  order: Orders;
+  loading: boolean;
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+export const ReceiptModal: VFC<Props> = memo((props) => {
+  const { order, loading, isOpen, onClose } = props;
+
+  // const onDeliveredButton = () => {
+  //   confirm('ご注文の商品を受け取りましたか？');
+  // };
+
+  const history = useHistory();
+
+  return (
+    <>
+      <Modal
+        size={'sm'}
+        isOpen={isOpen}
+        onClose={onClose}
+        autoFocus={false}
+        closeOnOverlayClick={false}
+        motionPreset="slideInBottom"
+      >
+        <ModalOverlay>
+          <ModalContent bg="white">
+            <ModalCloseButton
+              bgColor="white"
+              rounded="full"
+              _hover={{ opacity: 0.8 }}
+              onClick={() => history.push('/order_history')}
+            />
+            <ModalBody>
+              {loading ? (
+                <Center h="100vh">
+                  <Spinner />
+                </Center>
+              ) : (
+                <Wrap justify={'center'}>
+                  <VStack>
+                    <Text pt={8} fontSize={'3xl'} color={'brand'}>
+                      受取番号
+                    </Text>
+                    <Text fontSize={'7xl'} fontWeight={'bold'} color={'brand'}>
+                      {order.rceipt_number}
+                    </Text>
+                    <Text
+                      pt={2}
+                      fontSize={'xl'}
+                      fontWeight={'bold'}
+                      color={'brand'}
+                    >
+                      {order.restaurant_name}
+                    </Text>
+                    {order.order_details.map((detail, i) => (
+                      <WrapItem key={i}>
+                        <Box
+                          fontSize={'xl'}
+                          fontWeight={'bold'}
+                          color={'brand'}
+                          isTruncated
+                        >
+                          {detail.food_name}
+                        </Box>
+                      </WrapItem>
+                    ))}
+                    <Text fontSize={'xl'} fontWeight={'bold'} color={'brand'}>
+                      合計 ¥ {order.total_price.toLocaleString()}
+                    </Text>
+                  </VStack>
+                </Wrap>
+              )}
+            </ModalBody>
+            <Spacer />
+            <ModalFooter mx={'auto'} m={4}></ModalFooter>
+          </ModalContent>
+        </ModalOverlay>
+      </Modal>
+    </>
+  );
+});

--- a/frontend/src/components/pages/Cart.tsx
+++ b/frontend/src/components/pages/Cart.tsx
@@ -12,6 +12,8 @@ import { useDeleteCartDetails } from 'hooks/useDeleteCartDetails';
 import { useReplaceCart } from 'hooks/useReplaceCart';
 import { usePostOrders } from 'hooks/usePostOrders';
 import { useLoginUser } from 'hooks/useLoginUser';
+import { useDisclosure } from '@chakra-ui/react';
+import { ReceiptModal } from 'components/organisms/order/ReceiptModal';
 
 export const Cart: VFC = memo(() => {
   const { carts, loading } = useCartIndex();
@@ -33,10 +35,13 @@ export const Cart: VFC = memo(() => {
   }, [carts]);
 
   const { loginUser } = useLoginUser();
-  const { postOrders } = usePostOrders();
-  const onOrderButton = (userId: string) => {
-    postOrders(userId);
-    alert('受取票ページへ遷移');
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const { postOrders, order, loading: orderLoading } = usePostOrders();
+
+  const onOrderButton = async (userId: string) => {
+    await postOrders(userId).then(() => {
+      onOpen();
+    });
   };
 
   // Calculate the total amount
@@ -140,6 +145,14 @@ export const Cart: VFC = memo(() => {
             </CartButton>
           </VStack>
         </Wrap>
+      )}
+      {isOpen && (
+        <ReceiptModal
+          order={order}
+          loading={orderLoading}
+          isOpen={isOpen}
+          onClose={onClose}
+        />
       )}
     </>
   );

--- a/frontend/src/components/pages/MyPage.tsx
+++ b/frontend/src/components/pages/MyPage.tsx
@@ -32,7 +32,6 @@ export const MyPage: VFC = memo(() => {
           <Text>マイページ</Text>
         </VStack>
         <Stack spacing={4} py={4} px={10}>
-          <Divider borderColor="brand" my={4} />
           <Spacer />
           <Button
             bg="brand"

--- a/frontend/src/components/pages/OrderHistory.tsx
+++ b/frontend/src/components/pages/OrderHistory.tsx
@@ -50,17 +50,17 @@ export const OrderHistory: VFC = memo(() => {
           <HStack>
             <Box
               h={{ sm: '20px', md: '30px' }}
-              w={{ sm: '122px', md: '180px' }}
+              w={{ sm: '70px', md: '80px' }}
               fontSize={{ sm: 'xs', md: 'lg' }}
               fontWeight={'bold'}
               color={'brand'}
-              textAlign={'center'}
+              textAlign={'left'}
             >
               購入日時
             </Box>
             <Box
               h={{ sm: '20px', md: '30px' }}
-              w={{ sm: '122px', md: '180px' }}
+              w={{ sm: '80px', md: '180px' }}
               fontSize={{ sm: 'xs', md: 'lg' }}
               fontWeight={'bold'}
               color={'brand'}
@@ -70,7 +70,7 @@ export const OrderHistory: VFC = memo(() => {
             </Box>
             <Box
               h={{ sm: '20px', md: '30px' }}
-              w={{ sm: '122px', md: '180px' }}
+              w={{ sm: '110px', md: '180px' }}
               fontSize={{ sm: 'xs', md: 'lg' }}
               fontWeight={'bold'}
               color={'brand'}
@@ -79,14 +79,24 @@ export const OrderHistory: VFC = memo(() => {
               商品
             </Box>
             <Box
-              h={{ sm: '20px', md: '30px' }}
-              w={{ sm: '122px', md: '180px' }}
+              h={{ sm: '20pxs', md: '30px' }}
+              w={{ sm: '110px', md: '180px' }}
               fontSize={{ sm: 'xs', md: 'lg' }}
               fontWeight={'bold'}
               color={'brand'}
               textAlign={'center'}
             >
               金額
+            </Box>
+            <Box
+              h={{ sm: '20px', md: '30px' }}
+              w={{ sm: '70px', md: '80px' }}
+              fontSize={{ sm: 'xs', md: 'lg' }}
+              fontWeight={'bold'}
+              color={'brand'}
+              textAlign={'right'}
+            >
+              受取番号
             </Box>
           </HStack>
           <Divider w={'740px'} borderColor={'brand'} border={'1px'} />
@@ -101,6 +111,8 @@ export const OrderHistory: VFC = memo(() => {
                         restaurantName={order.restaurant_name}
                         totalPrice={order.total_price}
                         orderDetails={order.order_details}
+                        progressStatus={order.progress_status}
+                        receiptNumber={order.rceipt_number}
                       />
                     </WrapItem>
                   ))}

--- a/frontend/src/hooks/usePostOrders.ts
+++ b/frontend/src/hooks/usePostOrders.ts
@@ -10,11 +10,12 @@ import { useMessage } from './useMessage';
 export const usePostOrders = () => {
   const { showMessage } = useMessage();
   const [loading, setLoading] = useState(false);
+  const [order, setOrder] = useState<Orders>();
 
   const postOrders = useCallback(async (params) => {
     setLoading(true);
     try {
-      await axios.post<Orders>(
+      const result = await axios.post<Orders>(
         ordersUrl,
         {
           user_id: params,
@@ -27,11 +28,11 @@ export const usePostOrders = () => {
           },
         }
       );
-
       showMessage({
         title: '注文を確定しました',
         status: 'success',
       });
+      setOrder(result.data);
     } catch (e) {
       showMessage({
         title: 'データの取得に失敗しました',
@@ -42,5 +43,5 @@ export const usePostOrders = () => {
     }
   }, []);
 
-  return { postOrders, loading };
+  return { postOrders, order, loading };
 };


### PR DESCRIPTION
## issue
close #103 

## 実装の目的と概要
- 受取票モーダル実装

## 実装内容(技術的な点を記載)
- 画面遷移の流れ
  - 注文確定→受取票モーダル（閉じるボタン以外は押せない設定）→閉じるボタンを押すと、購入一覧画面へ遷移
 
## スクリーンショット（画面レイアウトを変更した場合）
### 画面名[受取票モーダルと画面遷移]


https://user-images.githubusercontent.com/42578729/161664661-a7d27d97-f56e-488f-8f83-5d361cc5f4a3.mov



- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] ローカル環境でrspecを実行してfailure, errorが出力されていないか(pendingはOK)
```
rspec spec/models
rspec spec/requests
```
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか

## 備考（実装していないことなど）
  - 購入履歴ページの「受取済」or「受取番号ボタン」の表示切り替えは、`orders` テーブルの `progress_status: delivered` で判定しており、店舗側機能が追加された場合にコントロールできる予定。
- 購入履歴ページの右側に受取番号ボタンを追加しましたが、受取票モーダル遷移は、別タスクとしました。現状では、ブラウザの `confirm` 表示で対応。
- #137