### PR TITLE
[フロント]修正リスト

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,6 +1,6 @@
 class Contact < ApplicationRecord
   belongs_to :user
-  validates :title,     presence: true, length: { maximum: 100 }
+  validates :title,     presence: true, length: { maximum: 50 }
   validates :content,   presence: true, length: { maximum: 2000 }
   validates :remote_ip, presence: true
   validates :status,    presence: true

--- a/app/serializers/order_serializer.rb
+++ b/app/serializers/order_serializer.rb
@@ -1,8 +1,12 @@
 class OrderSerializer < ActiveModel::Serializer
-  attributes :id, :user_id, :rceipt_number, :total_price, :consumption_tax, :progress_status, :restaurant_name, :created_at
+  attributes :id, :user_id, :rceipt_number, :total_price, :consumption_tax, :progress_status, :restaurant_name, :restaurant, :created_at
   has_many :order_details
 
   def restaurant_name
     object.order_details.first.food.restaurant.name
+  end
+
+  def restaurant
+    object.order_details.first.food.restaurant
   end
 end

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,2 +1,0 @@
-DISABLE_ESLINT_PLUGIN=true
-REACT_APP_SERVER_URL=https://www.benteku.com

--- a/frontend/src/components/atoms/button/SecondaryButton.tsx
+++ b/frontend/src/components/atoms/button/SecondaryButton.tsx
@@ -1,0 +1,25 @@
+import { memo, ReactNode, VFC } from 'react';
+import { Button } from '@chakra-ui/button';
+
+type Props = {
+  children: ReactNode;
+  disabled?: boolean;
+  loading?: boolean;
+  onClick: () => void;
+};
+
+export const SecondaryButton: VFC<Props> = memo((props) => {
+  const { children, disabled = false, loading = false, onClick } = props;
+  return (
+    <Button
+      bg="red.900"
+      color="white"
+      _hover={{ opacity: 0.8 }}
+      disabled={disabled || loading}
+      isLoading={loading}
+      onClick={onClick}
+    >
+      {children}
+    </Button>
+  );
+});

--- a/frontend/src/components/organisms/food/FoodOrderModal.tsx
+++ b/frontend/src/components/organisms/food/FoodOrderModal.tsx
@@ -24,6 +24,7 @@ import { FoodButton } from 'components/atoms/button/FoodButton';
 import { useLoginUser } from 'hooks/useLoginUser';
 import { useHistory } from 'react-router-dom';
 import { useReplaceCartDetails } from 'hooks/useReplaceCartDetails';
+import { useMessage } from 'hooks/useMessage';
 
 type Props = {
   food: Food;
@@ -56,6 +57,8 @@ export const FoodOrderModal: VFC<Props> = memo((props) => {
 
   const history = useHistory();
   const { loginUser } = useLoginUser();
+  const { showMessage } = useMessage();
+
   const onCartButton = async ({ food, count }) => {
     if (loginUser) {
       await postCart({ food: food, count: count })
@@ -76,6 +79,10 @@ export const FoodOrderModal: VFC<Props> = memo((props) => {
         });
     } else {
       history.push('/login');
+      showMessage({
+        title: 'ログインまたはアカウントを作成してください',
+        status: 'error',
+      });
     }
   };
 

--- a/frontend/src/components/organisms/layout/Header.tsx
+++ b/frontend/src/components/organisms/layout/Header.tsx
@@ -13,6 +13,7 @@ import { MenuDrawer } from 'components/molecules/MenuDrawer';
 import MainLogo from 'images/MainLogo.svg';
 import CartIcon from 'images/CartIcon.svg';
 import { CartModal } from '../cart/CartModal';
+import { useMessage } from 'hooks/useMessage';
 
 export const Header: VFC = memo(() => {
   const {
@@ -31,6 +32,7 @@ export const Header: VFC = memo(() => {
   const history = useHistory();
   const { loginUser } = useLoginUser();
   const { logout } = useAuth();
+  const { showMessage } = useMessage();
 
   const onHome = () => history.push('/');
   const onContact = () => history.push('/contact');
@@ -44,6 +46,10 @@ export const Header: VFC = memo(() => {
       onOpenCartModal();
     } else {
       history.push('/login');
+      showMessage({
+        title: 'ログインまたはアカウントを作成してください',
+        status: 'error',
+      });
     }
   };
 

--- a/frontend/src/components/organisms/order/OrderCard.tsx
+++ b/frontend/src/components/organisms/order/OrderCard.tsx
@@ -18,6 +18,7 @@ type Props = {
   progressStatus: string;
   receiptNumber: string;
   orderDetails: OrderDetail[];
+  onClick: () => void;
 };
 
 export const OrderCard: VFC<Props> = memo((props) => {
@@ -28,6 +29,7 @@ export const OrderCard: VFC<Props> = memo((props) => {
     progressStatus,
     receiptNumber,
     orderDetails,
+    onClick,
   } = props;
 
   const dateTime = new Date(createdAt).toLocaleDateString();
@@ -57,6 +59,8 @@ export const OrderCard: VFC<Props> = memo((props) => {
             fontSize={{ sm: 'xs', md: 'lg' }}
             fontWeight={'bold'}
             isTruncated
+            _hover={{ cursor: 'pointer', opacity: 0.6 }}
+            onClick={onClick}
           >
             {restaurantName}
           </Box>

--- a/frontend/src/components/pages/Cart.tsx
+++ b/frontend/src/components/pages/Cart.tsx
@@ -61,6 +61,8 @@ export const Cart: VFC = memo(() => {
       );
   }, [carts]);
 
+  useEffect(() => window.scrollTo(0, 0));
+
   return (
     <>
       {loading ? (

--- a/frontend/src/components/pages/CommercialTransactionsLaw.tsx
+++ b/frontend/src/components/pages/CommercialTransactionsLaw.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable arrow-body-style */
-import { memo, VFC } from 'react';
+import { memo, useEffect, VFC } from 'react';
 import { Divider, Flex, Spacer, Stack, Text } from '@chakra-ui/layout';
 import {
   Table,
@@ -13,6 +13,8 @@ import {
 } from '@chakra-ui/react';
 
 export const CommercialTransactionsLaw: VFC = memo(() => {
+  useEffect(() => window.scrollTo(0, 0));
+
   return (
     <Flex align="center" justify="center" height={{ sm: '90vh', md: '140vh' }}>
       <Stack w={{ sm: 'md', md: '2xl' }}>

--- a/frontend/src/components/pages/Contact.tsx
+++ b/frontend/src/components/pages/Contact.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable arrow-body-style */
-import { ChangeEvent, memo, useState, VFC } from 'react';
+import { ChangeEvent, memo, useEffect, useState, VFC } from 'react';
 import {
   FormControl,
   FormErrorMessage,
@@ -12,6 +12,7 @@ import { usePostContact } from 'hooks/usePostContact';
 import { PrimaryButton } from 'components/atoms/button/PrimaryButton';
 import { ContactParams } from 'types/api/contact';
 import { useHistory } from 'react-router-dom';
+import { useLoginUser } from 'hooks/useLoginUser';
 
 const TITLE_MAX_LENGTH = 50;
 const CONTENT_MAX_LENGTH = 2000;
@@ -21,6 +22,7 @@ export const Contact: VFC = memo(() => {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const history = useHistory();
+  const { loginUser } = useLoginUser();
 
   const onChangeTitle = (e: ChangeEvent<HTMLInputElement>) =>
     setTitle(e.target.value);
@@ -37,8 +39,11 @@ export const Contact: VFC = memo(() => {
     await postContact(params), history.push('/');
   };
 
+  const isLoginError = loginUser === undefined;
   const isTitleError = title.length > TITLE_MAX_LENGTH;
   const isContentError = content.length > CONTENT_MAX_LENGTH;
+
+  useEffect(() => window.scrollTo(0, 0));
 
   return (
     <>
@@ -54,6 +59,13 @@ export const Contact: VFC = memo(() => {
             お問い合わせ
           </Text>
           <Divider p={2} w={'97.5%'} borderColor="brand" />
+          <FormControl isInvalid={isLoginError}>
+            {isLoginError && (
+              <FormErrorMessage>
+                ログインまたはアカウントを作成してください
+              </FormErrorMessage>
+            )}
+          </FormControl>
           <FormControl isInvalid={isTitleError}>
             <FormLabel fontWeight={'bold'}>
               件 名
@@ -101,7 +113,13 @@ export const Contact: VFC = memo(() => {
           </FormControl>
           <Spacer p={2} />
           <PrimaryButton
-            disabled={!title || !content || isTitleError || isContentError}
+            disabled={
+              !title ||
+              !content ||
+              isTitleError ||
+              isContentError ||
+              isLoginError
+            }
             loading={loading}
             onClick={onContact}
           >

--- a/frontend/src/components/pages/Contact.tsx
+++ b/frontend/src/components/pages/Contact.tsx
@@ -1,11 +1,20 @@
 /* eslint-disable arrow-body-style */
 import { ChangeEvent, memo, useState, VFC } from 'react';
-import { Input, Textarea } from '@chakra-ui/react';
-import { Divider, Spacer, Stack, Text, VStack } from '@chakra-ui/layout';
+import {
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  Input,
+  Textarea,
+} from '@chakra-ui/react';
+import { Badge, Divider, Spacer, Stack, Text, VStack } from '@chakra-ui/layout';
 import { usePostContact } from 'hooks/usePostContact';
 import { PrimaryButton } from 'components/atoms/button/PrimaryButton';
 import { ContactParams } from 'types/api/contact';
 import { useHistory } from 'react-router-dom';
+
+const TITLE_MAX_LENGTH = 50;
+const CONTENT_MAX_LENGTH = 2000;
 
 export const Contact: VFC = memo(() => {
   const { postContact, loading } = usePostContact();
@@ -28,6 +37,9 @@ export const Contact: VFC = memo(() => {
     await postContact(params), history.push('/');
   };
 
+  const isTitleError = title.length > TITLE_MAX_LENGTH;
+  const isContentError = content.length > CONTENT_MAX_LENGTH;
+
   return (
     <>
       <VStack align="center">
@@ -42,28 +54,54 @@ export const Contact: VFC = memo(() => {
             お問い合わせ
           </Text>
           <Divider p={2} w={'97.5%'} borderColor="brand" />
-          <Text>件名（必須）</Text>
-          <Input
-            borderColor="gray.300"
-            placeholder="件名を入力してください"
-            _placeholder={{ color: 'gray.300' }}
-            value={title}
-            onChange={onChangeTitle}
-          />
+          <FormControl isInvalid={isTitleError}>
+            <FormLabel fontWeight={'bold'}>
+              件 名
+              <Badge variant="outline" ml="2">
+                必須
+              </Badge>
+              <Badge variant="outline" ml="1">
+                50文字まで
+              </Badge>
+            </FormLabel>
+            <Input
+              borderColor="gray.300"
+              placeholder="件名を入力してください"
+              _placeholder={{ color: 'gray.300' }}
+              value={title}
+              onChange={onChangeTitle}
+            />
+            {isTitleError && (
+              <FormErrorMessage>50文字を超えています</FormErrorMessage>
+            )}
+          </FormControl>
           <Spacer />
-          <Text>お問い合わせ内容（必須）</Text>
-          <Textarea
-            h={'36'}
-            borderColor="gray.300"
-            placeholder="お問い合わせ内容を入力してください"
-            _placeholder={{ color: 'gray.300' }}
-            _hover={{ color: 'gray.600' }}
-            value={content}
-            onChange={onChangeContent}
-          />
+          <FormControl isInvalid={isContentError}>
+            <FormLabel fontWeight={'bold'}>
+              お問い合わせ内容
+              <Badge variant="outline" ml="2">
+                必須
+              </Badge>
+              <Badge variant="outline" ml="1">
+                2000文字まで
+              </Badge>
+            </FormLabel>
+            <Textarea
+              h={'36'}
+              borderColor="gray.300"
+              placeholder="お問い合わせ内容を入力してください"
+              _placeholder={{ color: 'gray.300' }}
+              _hover={{ color: 'gray.600' }}
+              value={content}
+              onChange={onChangeContent}
+            />
+            {isContentError && (
+              <FormErrorMessage>2000文字を超えています</FormErrorMessage>
+            )}
+          </FormControl>
           <Spacer p={2} />
           <PrimaryButton
-            disabled={!title || !content}
+            disabled={!title || !content || isTitleError || isContentError}
             loading={loading}
             onClick={onContact}
           >

--- a/frontend/src/components/pages/Contact.tsx
+++ b/frontend/src/components/pages/Contact.tsx
@@ -61,7 +61,7 @@ export const Contact: VFC = memo(() => {
           <Divider p={2} w={'97.5%'} borderColor="brand" />
           <FormControl isInvalid={isLoginError}>
             {isLoginError && (
-              <FormErrorMessage>
+              <FormErrorMessage fontWeight={'bold'}>
                 ログインまたはアカウントを作成してください
               </FormErrorMessage>
             )}

--- a/frontend/src/components/pages/Foods.tsx
+++ b/frontend/src/components/pages/Foods.tsx
@@ -70,6 +70,8 @@ export const Foods: VFC = memo(() => {
     getFoods(restaurantId);
   }, []);
 
+  useEffect(() => window.scrollTo(0, 0));
+
   return (
     <>
       {loading ? (

--- a/frontend/src/components/pages/Foods.tsx
+++ b/frontend/src/components/pages/Foods.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable no-constant-condition */
 /* eslint-disable arrow-body-style */

--- a/frontend/src/components/pages/HowToUseBenteku.tsx
+++ b/frontend/src/components/pages/HowToUseBenteku.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable arrow-body-style */
-import { memo, VFC } from 'react';
+import { memo, useEffect, VFC } from 'react';
 import { HStack, Spacer, Text, VStack } from '@chakra-ui/layout';
 import { Image } from '@chakra-ui/react';
 import SelectADish from 'images/SelectADish.svg';
@@ -7,6 +7,7 @@ import PlaceOrder from 'images/PlaceOrder.svg';
 import PickUp from 'images/PickUp.svg';
 
 export const HowToUseBenteku: VFC = memo(() => {
+  useEffect(() => window.scrollTo(0, 0));
   return (
     <VStack h={{ sm: '140vh', md: '72vh' }}>
       <Text

--- a/frontend/src/components/pages/Login.tsx
+++ b/frontend/src/components/pages/Login.tsx
@@ -1,7 +1,14 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable arrow-body-style */
-import { ChangeEvent, memo, useCallback, useState, VFC } from 'react';
+import {
+  ChangeEvent,
+  memo,
+  useCallback,
+  useEffect,
+  useState,
+  VFC,
+} from 'react';
 import {
   Input,
   Box,
@@ -51,9 +58,12 @@ export const Login: VFC = memo(() => {
   }, [history]);
 
   const onGuestLogin = () => guestLogin();
+
+  useEffect(() => window.scrollTo(0, 0));
+
   return (
-    <Flex bg="gray.200" align="center" justify="center" height="70vh">
-      <Box bg="white" w="sm" p={4} borderRadius="md" shadow="md">
+    <Flex bg="gray.200" align="center" justify="center">
+      <Box m={10} bg="white" w="sm" p={4} borderRadius="md" shadow="md">
         <VStack
           fontSize="23px"
           fontWeight="bold"

--- a/frontend/src/components/pages/MyPage.tsx
+++ b/frontend/src/components/pages/MyPage.tsx
@@ -96,7 +96,7 @@ export const MyPage: VFC = memo(() => {
 
   return (
     <>
-      <Flex align="top" justify="center" height="85vh">
+      <Flex align="top" justify="center">
         <Box bg="white" w={'md'} h={'3xl'} p={2}>
           <VStack
             paddingTop="8"

--- a/frontend/src/components/pages/MyPage.tsx
+++ b/frontend/src/components/pages/MyPage.tsx
@@ -94,6 +94,8 @@ export const MyPage: VFC = memo(() => {
       setUserPhoneNumber(loginUser?.phone_number ?? ''));
   }, [loginUser]);
 
+  useEffect(() => window.scrollTo(0, 0));
+
   return (
     <>
       <Flex align="top" justify="center">

--- a/frontend/src/components/pages/MyPage.tsx
+++ b/frontend/src/components/pages/MyPage.tsx
@@ -8,12 +8,18 @@ import {
   VFC,
 } from 'react';
 import { useHistory } from 'react-router-dom';
-import { Input } from '@chakra-ui/react';
+import {
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  Input,
+} from '@chakra-ui/react';
 import { Box, Flex, Spacer, Stack, Text, VStack } from '@chakra-ui/layout';
 import { User } from 'types/api/user';
 import { useLoginUser } from 'hooks/useLoginUser';
 import { useMyPage } from 'hooks/useMyPage';
 import { PrimaryButton } from 'components/atoms/button/PrimaryButton';
+import { SecondaryButton } from 'components/atoms/button/SecondaryButton';
 
 export const MyPage: VFC = memo(() => {
   const [userId, setUserId] = useState('');
@@ -84,6 +90,10 @@ export const MyPage: VFC = memo(() => {
     email: userEmail,
     phone_number: userPhoneNumber,
   };
+
+  const regExpPhone = /[0-9]{10,11}/;
+  const isPhoneNumberError =
+    !regExpPhone.test(userPhoneNumber) && userPhoneNumber !== '';
 
   useEffect(() => {
     loginUser &&
@@ -161,30 +171,35 @@ export const MyPage: VFC = memo(() => {
                 {userKana}
               </Box>
             )}
-            <Text pt={2} color={'gray.600'}>
-              電話番号（数字のみ入力）
-            </Text>
-            {isEdit ? (
-              <Input
-                borderColor="gray.300"
-                placeholder="電話番号を入力してください"
-                _placeholder={{ color: 'gray.300' }}
-                _hover={{ color: 'gray.600' }}
-                value={userPhoneNumber}
-                onChange={onChangePhoneNumber}
-                isReadOnly={!isEdit}
-              />
-            ) : (
-              <Box
-                pb={2}
-                pl={4}
-                fontSize={'xl'}
-                borderBottom={'1px'}
-                borderColor={'gray.400'}
-              >
-                {userPhoneNumber}
-              </Box>
-            )}
+            <FormControl isInvalid={isPhoneNumberError}>
+              <FormLabel pt={2} color={'gray.600'}>
+                電話番号（半角数字のみ入力）
+              </FormLabel>
+              {isEdit ? (
+                <Input
+                  borderColor="gray.300"
+                  placeholder="電話番号を入力してください"
+                  _placeholder={{ color: 'gray.300' }}
+                  _hover={{ color: 'gray.600' }}
+                  value={userPhoneNumber}
+                  onChange={onChangePhoneNumber}
+                  isReadOnly={!isEdit}
+                />
+              ) : (
+                <Box
+                  pb={2}
+                  pl={4}
+                  fontSize={'xl'}
+                  borderBottom={'1px'}
+                  borderColor={'gray.400'}
+                >
+                  {userPhoneNumber}
+                </Box>
+              )}
+              {isPhoneNumberError && (
+                <FormErrorMessage>電話番号が不正です</FormErrorMessage>
+              )}
+            </FormControl>
             <Spacer p={4}></Spacer>
             {!isEdit && (
               <PrimaryButton
@@ -218,7 +233,7 @@ export const MyPage: VFC = memo(() => {
               購入履歴
             </PrimaryButton>
             <Spacer p={4} />
-            <PrimaryButton
+            <SecondaryButton
               disabled={
                 editLoading ||
                 updateLoading ||
@@ -229,7 +244,7 @@ export const MyPage: VFC = memo(() => {
               onClick={() => onUnsubscribeButton()}
             >
               退会する
-            </PrimaryButton>
+            </SecondaryButton>
           </Stack>
         </Box>
       </Flex>

--- a/frontend/src/components/pages/NewUserRegistration.tsx
+++ b/frontend/src/components/pages/NewUserRegistration.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable arrow-body-style */
-import { ChangeEvent, memo, useState, VFC } from 'react';
+import { ChangeEvent, memo, useEffect, useState, VFC } from 'react';
 import {
   Input,
   Box,
@@ -63,9 +63,11 @@ export const NewUserRegistration: VFC = memo(() => {
   const onClickPolicy = () => history.push('/policy');
   const onClickTermsOfUse = () => history.push('/terms_of_use');
 
+  useEffect(() => window.scrollTo(0, 0));
+
   return (
-    <Flex bg="gray.200" align="center" justify="center" height="95vh">
-      <Box bg="white" p={2} borderRadius="md" shadow="md">
+    <Flex bg="gray.200" align="center" justify="center">
+      <Box m={'10'} bg="white" p={2} borderRadius="md" shadow="md">
         <VStack fontSize="23px" fontWeight="bold" color="brand" spacing="12px">
           <Text>お弁当テイクアウトアプリ</Text>
           <Text>アカウントを作成</Text>

--- a/frontend/src/components/pages/NewUserRegistration.tsx
+++ b/frontend/src/components/pages/NewUserRegistration.tsx
@@ -12,6 +12,9 @@ import {
   Checkbox,
   Spacer,
   Button,
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
 } from '@chakra-ui/react';
 
 import { SignUpParams } from 'types/api/sign';
@@ -63,6 +66,27 @@ export const NewUserRegistration: VFC = memo(() => {
   const onClickPolicy = () => history.push('/policy');
   const onClickTermsOfUse = () => history.push('/terms_of_use');
 
+  const regExpEmail =
+    /^[a-zA-Z0-9_+-]+(.[a-zA-Z0-9_+-]+)*@([a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]*\.)+[a-zA-Z]{2,}$/;
+  const isEmailError = !regExpEmail.test(userId) && userId !== '';
+
+  const isPasswordNumberError =
+    userPassword !== '' &&
+    (userPassword.length < 6 || 24 < userPassword.length);
+
+  const regExpPassword = /^[a-zA-Z0-9.?/-]+$/;
+
+  const isPasswordCharacterError =
+    !regExpPassword.test(userPassword) && userPassword !== '';
+
+  const isPasswordConfirmationError =
+    userPasswordConfirmation !== '' &&
+    userPassword !== userPasswordConfirmation;
+
+  const regExpPhone = /[0-9]{10,11}/;
+  const isPhoneNumberError =
+    !regExpPhone.test(userPhoneNumber) && userPhoneNumber !== '';
+
   useEffect(() => window.scrollTo(0, 0));
 
   return (
@@ -74,7 +98,7 @@ export const NewUserRegistration: VFC = memo(() => {
         </VStack>
         <Divider borderColor="brand" my={4} />
         <Stack spacing={4} py={4} px={10}>
-          <Text h="2">名前</Text>
+          <FormLabel h="0">名前</FormLabel>
           <Input
             borderColor="gray.300"
             placeholder="名前を入力してください"
@@ -83,7 +107,7 @@ export const NewUserRegistration: VFC = memo(() => {
             value={userName}
             onChange={onChangeName}
           />
-          <Text h="2">フリガナ</Text>
+          <FormLabel h="2">フリガナ</FormLabel>
           <Input
             borderColor="gray.300"
             placeholder="フリガナを入力してください"
@@ -92,44 +116,71 @@ export const NewUserRegistration: VFC = memo(() => {
             value={userKana}
             onChange={onChangeKana}
           />
-          <Text h="2">Eメールアドレス</Text>
-          <Input
-            borderColor="gray.300"
-            placeholder="Eメールを入力してください"
-            _placeholder={{ color: 'gray.300' }}
-            _hover={{ color: 'gray.600' }}
-            value={userId}
-            onChange={onChangeId}
-          />
-          <Text h="2">パスワード</Text>
-          <Input
-            borderColor="gray.300"
-            placeholder="パスワードを入力してください"
-            _placeholder={{ color: 'gray.300' }}
-            _hover={{ color: 'gray.600' }}
-            type="password"
-            value={userPassword}
-            onChange={onChangePassword}
-          />
-          <Text h="2">確認用パスワード</Text>
-          <Input
-            borderColor="gray.300"
-            placeholder="パスワードを入力してください"
-            _placeholder={{ color: 'gray.300' }}
-            _hover={{ color: 'gray.600' }}
-            type="password"
-            value={userPasswordConfirmation}
-            onChange={onChangePasswordConfirmation}
-          />
-          <Text h="2">電話番号（数字のみ入力）</Text>
-          <Input
-            borderColor="gray.300"
-            placeholder="電話番号を入力してください"
-            _placeholder={{ color: 'gray.300' }}
-            _hover={{ color: 'gray.600' }}
-            value={userPhoneNumber}
-            onChange={onChangePhoneNumber}
-          />
+          <FormControl isInvalid={isEmailError}>
+            <FormLabel h="4">Eメールアドレス</FormLabel>
+            <Input
+              borderColor="gray.300"
+              placeholder="Eメールを入力してください"
+              _placeholder={{ color: 'gray.300' }}
+              _hover={{ color: 'gray.600' }}
+              value={userId}
+              onChange={onChangeId}
+            />
+            {isEmailError && (
+              <FormErrorMessage>Eメールアドレスが不正です</FormErrorMessage>
+            )}
+          </FormControl>
+          <FormControl
+            isInvalid={isPasswordNumberError || isPasswordCharacterError}
+          >
+            <FormLabel h="4">パスワード（6~24文字）</FormLabel>
+            <Input
+              borderColor="gray.300"
+              placeholder="パスワードを入力してください"
+              _placeholder={{ color: 'gray.300' }}
+              _hover={{ color: 'gray.600' }}
+              type="password"
+              value={userPassword}
+              onChange={onChangePassword}
+            />
+            {isPasswordNumberError && (
+              <FormErrorMessage>文字数が不正です</FormErrorMessage>
+            )}
+            {isPasswordCharacterError && (
+              <FormErrorMessage>
+                認証できない文字が含まれています
+              </FormErrorMessage>
+            )}
+          </FormControl>
+          <FormControl isInvalid={isPasswordConfirmationError}>
+            <FormLabel h="4">確認用パスワード</FormLabel>
+            <Input
+              borderColor="gray.300"
+              placeholder="パスワードを入力してください"
+              _placeholder={{ color: 'gray.300' }}
+              _hover={{ color: 'gray.600' }}
+              type="password"
+              value={userPasswordConfirmation}
+              onChange={onChangePasswordConfirmation}
+            />
+            {isPasswordConfirmationError && (
+              <FormErrorMessage>パスワードが一致していません</FormErrorMessage>
+            )}
+          </FormControl>
+          <FormControl isInvalid={isPhoneNumberError}>
+            <FormLabel h="4">電話番号（半角数字のみ入力）</FormLabel>
+            <Input
+              borderColor="gray.300"
+              placeholder="電話番号を入力してください"
+              _placeholder={{ color: 'gray.300' }}
+              _hover={{ color: 'gray.600' }}
+              value={userPhoneNumber}
+              onChange={onChangePhoneNumber}
+            />
+            {isPhoneNumberError && (
+              <FormErrorMessage>電話番号が不正です</FormErrorMessage>
+            )}
+          </FormControl>
           <Divider borderColor="brand" my={4} />
           <VStack spacing={2} align="center">
             <Button color="brand" variant="link" onClick={onClickPolicy}>
@@ -158,7 +209,12 @@ export const NewUserRegistration: VFC = memo(() => {
               !userPassword ||
               !userPasswordConfirmation ||
               !userPhoneNumber ||
-              !isChecked
+              !isChecked ||
+              isEmailError ||
+              isPasswordNumberError ||
+              isPasswordCharacterError ||
+              isPasswordConfirmationError ||
+              isPhoneNumberError
             }
             loading={newUserRegistrationLoading}
             onClick={onClickNewRegistration}

--- a/frontend/src/components/pages/OrderHistory.tsx
+++ b/frontend/src/components/pages/OrderHistory.tsx
@@ -24,6 +24,8 @@ export const OrderHistory: VFC = memo(() => {
     orders;
   });
 
+  useEffect(() => window.scrollTo(0, 0));
+
   const history = useHistory();
 
   const onBackButton = () => history.push('/my_page');

--- a/frontend/src/components/pages/OrderHistory.tsx
+++ b/frontend/src/components/pages/OrderHistory.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable arrow-body-style */
-import { memo, useEffect, VFC } from 'react';
+import { memo, useCallback, useEffect, VFC } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Button, Spinner } from '@chakra-ui/react';
 import {
@@ -27,6 +27,17 @@ export const OrderHistory: VFC = memo(() => {
   const history = useHistory();
 
   const onBackButton = () => history.push('/my_page');
+
+  const onRestaurant = useCallback(
+    (order) => {
+      const restaurant = order.restaurant;
+      history.push({
+        pathname: `restaurants/${order.restaurant.id}/foods`,
+        state: { restaurant },
+      });
+    },
+    [history]
+  );
 
   return (
     <>
@@ -118,6 +129,7 @@ export const OrderHistory: VFC = memo(() => {
                           orderDetails={order.order_details}
                           progressStatus={order.progress_status}
                           receiptNumber={order.rceipt_number}
+                          onClick={() => onRestaurant(order)}
                         />
                       </WrapItem>
                     ))}

--- a/frontend/src/components/pages/Policy.tsx
+++ b/frontend/src/components/pages/Policy.tsx
@@ -8,10 +8,10 @@ export const Policy: VFC = memo(() => {
   });
 
   return (
-    <Flex align="center" justify="center" height={{ sm: '880vh', md: '735vh' }}>
+    <Flex align="center" justify="center">
       <Stack w={{ sm: 'md', md: '2xl' }}>
         <Text
-          paddingTop="3"
+          paddingTop="20"
           fontSize="26px"
           fontWeight="bold"
           color="brand"

--- a/frontend/src/components/pages/Restaurants.tsx
+++ b/frontend/src/components/pages/Restaurants.tsx
@@ -22,6 +22,7 @@ import CafeTime from 'images/CafeTime.jpg';
 export const Restaurants: VFC = memo(() => {
   const { getRestaurants, restaurants, loading } = useRestaurants();
   useEffect(() => getRestaurants(), []);
+  useEffect(() => window.scrollTo(0, 0));
 
   const history = useHistory();
 

--- a/frontend/src/components/pages/Restaurants.tsx
+++ b/frontend/src/components/pages/Restaurants.tsx
@@ -42,7 +42,7 @@ export const Restaurants: VFC = memo(() => {
         </Center>
       ) : (
         <>
-          <Wrap h={'48vh'} justify={'center'} paddingTop={10}>
+          <Wrap justify={'center'} paddingTop={10}>
             <Text
               paddingTop="5"
               paddingBottom="5"
@@ -91,6 +91,7 @@ export const Restaurants: VFC = memo(() => {
               </VStack>
               <WrapItem>
                 <Image
+                  paddingBottom={'2'}
                   maxW="600px"
                   w={['300px', '400px', '500px', '600px']}
                   src={Toppageimage}

--- a/frontend/src/components/pages/TermsOfUse.tsx
+++ b/frontend/src/components/pages/TermsOfUse.tsx
@@ -16,10 +16,10 @@ export const TermsOfUse: VFC = memo(() => {
   });
 
   return (
-    <Flex align="center" justify="center" height={{ sm: '590vh', md: '465vh' }}>
+    <Flex align="center" justify="center">
       <Stack w={{ sm: 'md', md: '2xl' }}>
         <Text
-          paddingTop="3"
+          paddingTop="20"
           fontSize="26px"
           fontWeight="bold"
           color="brand"

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -39,7 +39,6 @@ export const useAuth = () => {
         history.push('/');
         showMessage({ title: 'ログインしました', status: 'success' });
       } catch (e) {
-        alert(e);
         showMessage({
           title: 'ユーザID、パスワードの入力に誤りがあるか登録されていません。',
           status: 'error',

--- a/frontend/src/types/api/orders.ts
+++ b/frontend/src/types/api/orders.ts
@@ -1,3 +1,5 @@
+import { Restaurant } from './restaurant';
+
 export type Orders = {
   id?: number;
   user_id?: number;
@@ -8,6 +10,7 @@ export type Orders = {
   restaurant_name?: string;
   created_at?: string;
   order_details?: OrderDetail[];
+  restaurant?: Restaurant[];
 };
 
 export type OrderDetail = {

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,7 +1,0 @@
-{
-  "name": "obento_takeout_app",
-  "version": "1.0.0",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
## issue
close #159 

## 実装の目的と概要
- 各ページの調整

## 実装内容
- トップページ画面の、フルページの時に、レストラン画像とのスペース調整
<img width="1439" alt="トップページ" src="https://user-images.githubusercontent.com/42578729/169056171-5c42448d-916f-4619-952a-ef105d2c4e17.png">

- google mapの設定をherokuに追加する。→修正したので、`heroku push` 後に確認
→後ほど、要確認
- 購入履歴ページの店名から店舗ページへリンクする

https://user-images.githubusercontent.com/42578729/169069680-91afc8bf-2954-4117-afb1-516fcf79922d.mov


- mypageのレイアウトを修正する（フッターが重なるので）
→済
- お問い合わせ
    - お問い合わせの文字制限を件名：50文字に変更
    - 文字数制限以上のときに、送信に失敗しましたになるので、フォームに（○文字を超えています）等の表示を追加
    - ログインしていない場合は、アカウントを作成してください。と表示する

https://user-images.githubusercontent.com/42578729/169072623-1a512dde-ec9a-4562-9458-4bb8412b1fee.mov


- 未ログイン時にカートをクリックまたはフードモーダルからフードを追加した時、ログイン画面に遷移した後「アカウントを作成してください」と表示する

https://user-images.githubusercontent.com/42578729/169073018-3b09ec11-e515-44f0-a073-a5cfb6c8f45e.mov


- 全ページ表示時に一番上にそろえるよう設定追加
- useAuth.ts:42のalert(e);を削除
- mac画面と通常モニターと両方とも表示を確認

- 新規登録画面の修正
    - ログイン時に、emailの@がない時など、バリデーションメッセージを表示させる
    - 新規登録のパスワードが一致しない時にバリデーションをかける
  

https://user-images.githubusercontent.com/42578729/169073580-5d023c1d-ecd6-4b7c-b6dd-fd5451c1ba6d.mov



- 基本情報
    - 電話番号の（数字のみ入力）
    - 退会時のボタンをエンジ色にする？要検討

https://user-images.githubusercontent.com/42578729/169073856-90c196e0-cf26-4052-b9a9-f18518d863f5.mov



## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] ローカル環境でrspecを実行してfailure, errorが出力されていないか(pendingはOK)
```
rspec spec/models
rspec spec/requests
```
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか

## 備考（下記は別タスク）
### フロントエンド
- 新規登録から、利用規約とプライバシーポリシーの表示後、新規登録画面にリダイレクト（新規登録画面の入力しかけの文字が消えてしまう）

### バックエンド
 - バリデーションをモデルに追加する、テストも書く（nameの文字数制限、email、phone_number）255文字が保存でき、256文字の境界値をテストする、文字数を検討し直す
- 保存時のチェック

### 優先度低
- フード追加時から、アカウント作成した後のページ遷移はredirect_back　的な動きのようがよい（優先度は低い）
- カートに何か入っていると個数とか表示がわかるようにするとベスト（優先度低）