### PR TITLE
heroku push のバグを修正 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,6 @@
 # frontend
 frontend/node_modules
 frontend/.env
-frontend/.env.production
 
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,2 @@
+DISABLE_ESLINT_PLUGIN=true
+REACT_APP_SERVER_URL=https://www.benteku.com

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7213,13 +7213,19 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001279",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001279.tgz",
-      "integrity": "sha512-VfEHpzHEXj6/CxggTwSFoZBBYGQfQv9Cf42KPlO79sWXCD1QNKWKsKzFeWL7QpZHJQYAvocqV6Rty1yJMkqWLQ==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "version": "1.0.30001341",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001341.tgz",
+      "integrity": "sha512-2SodVrFFtvGENGCv0ChVJIDQ0KPaS1cg7/qtfMaICgeMolDdo/Z2OD32F0Aq9yl6F4YFwGPBS5AaPqNYiW4PoA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/capital-case": {
       "version": "1.0.4",
@@ -30430,9 +30436,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001279",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001279.tgz",
-      "integrity": "sha512-VfEHpzHEXj6/CxggTwSFoZBBYGQfQv9Cf42KPlO79sWXCD1QNKWKsKzFeWL7QpZHJQYAvocqV6Rty1yJMkqWLQ=="
+      "version": "1.0.30001341",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001341.tgz",
+      "integrity": "sha512-2SodVrFFtvGENGCv0ChVJIDQ0KPaS1cg7/qtfMaICgeMolDdo/Z2OD32F0Aq9yl6F4YFwGPBS5AaPqNYiW4PoA=="
     },
     "capital-case": {
       "version": "1.0.4",


### PR DESCRIPTION
## issue
- なし

## 実装の目的と概要
- `heroku push` ができなくなる不具合を修正
- エラー内容（一部）
```
Failed to load config "prettier" to extend from.
Referenced from: /tmp/build_ed37b939/frontend/.eslintrc.json
```
## 原因
- 前タスク時に、`gitignore` に `.env.production` を追加したが、内容に含まれている`DISABLE_ESLINT_PLUGIN=true` も無効になってしまうため、不具合が発生していた。

## 修正内容
- `gitignore` から `.env.production` を削除した
- 同時にGOOGLE_MAP_API_KEYをheroku settingsに追加し、Google cloud apiも修正し、`https://www.benteku.com` の本番環境でもGoogle mapが表示されるように設定

## 備考
- エラー内容（参考までに全体）
```
╰─○ git push heroku HEAD:main
Enumerating objects: 19, done.
Counting objects: 100% (19/19), done.
Delta compression using up to 8 threads
Compressing objects: 100% (11/11), done.
Writing objects: 100% (11/11), 2.26 KiB | 2.26 MiB/s, done.
Total 11 (delta 7), reused 0 (delta 0), pack-reused 0
remote: Compressing source files... done.
remote: Building source:
remote:
remote: -----> Building on the Heroku-20 stack
remote: -----> Using buildpacks:
remote:        1. heroku/nodejs
remote:        2. heroku/ruby
remote:        3. https://github.com/heroku/heroku-buildpack-static.git
remote: -----> Node.js app detected
remote:
remote: -----> Creating runtime environment
remote:
remote:        NPM_CONFIG_LOGLEVEL=error
remote:        NODE_VERBOSE=false
remote:        NODE_ENV=production
remote:        NODE_MODULES_CACHE=true
remote:
remote: -----> Installing binaries
remote:        engines.node (package.json):  14.x
remote:        engines.npm (package.json):   unspecified (use default)
remote:
remote:        Resolving node version 14.x...
remote:        Downloading and installing node 14.19.3...
remote:        Using default npm version: 6.14.17
remote:
remote: -----> Restoring cache
remote:        Cached directories were not restored due to a change in version of node, npm, yarn or stack
remote:        Module installation may take longer for this build
remote:
remote: -----> Installing dependencies
remote:        Installing node modules
remote:        added 0 packages in 0.028s
remote:
remote: -----> Build
remote:        Detected both "build" and "heroku-postbuild" scripts
remote:        Running heroku-postbuild
remote:
remote:        > obento_takeout_app@1.0.0 heroku-postbuild /tmp/build_ed37b939
remote:        > npm run build && npm run deploy && echo 'Client built!'
remote:
remote:
remote:        > obento_takeout_app@1.0.0 build /tmp/build_ed37b939
remote:        > cd frontend && npm install && npm run build && cd ..
remote:
remote:
remote:        > core-js@2.6.12 postinstall /tmp/build_ed37b939/frontend/node_modules/babel-runtime/node_modules/core-js
remote:        > node -e "try{require('./postinstall')}catch(e){}"
remote:
remote:
remote:        > core-js@3.19.1 postinstall /tmp/build_ed37b939/frontend/node_modules/core-js
remote:        > node -e "try{require('./postinstall')}catch(e){}"
remote:
remote:
remote:        > core-js-pure@3.19.1 postinstall /tmp/build_ed37b939/frontend/node_modules/core-js-pure
remote:        > node -e "try{require('./postinstall')}catch(e){}"
remote:
remote:
remote:        > ejs@2.7.4 postinstall /tmp/build_ed37b939/frontend/node_modules/ejs
remote:        > node ./postinstall.js
remote:
remote:        added 2204 packages from 793 contributors and audited 2277 packages in 35.978s
remote:
remote:        158 packages are looking for funding
remote:          run `npm fund` for details
remote:
remote:        found 46 vulnerabilities (2 low, 14 moderate, 15 high, 15 critical)
remote:          run `npm audit fix` to fix them, or `npm audit` for details
remote:
remote:        > frontend@0.1.0 build /tmp/build_ed37b939/frontend
remote:        > react-scripts build
remote:
remote:        Creating an optimized production build...
remote:        Failed to compile.
remote:
remote:        Failed to load config "prettier" to extend from.
remote:        Referenced from: /tmp/build_ed37b939/frontend/.eslintrc.json
remote:
remote:
remote: npm ERR! code ELIFECYCLE
remote: npm ERR! errno 1
remote: npm ERR! frontend@0.1.0 build: `react-scripts build`
remote: npm ERR! Exit status 1
remote: npm ERR!
remote: npm ERR! Failed at the frontend@0.1.0 build script.
remote: npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
remote:
remote: npm ERR! A complete log of this run can be found in:
remote: npm ERR!     /tmp/npmcache.s4Cu1/_logs/2022-05-25T05_05_25_277Z-debug.log
remote: npm ERR! code ELIFECYCLE
remote: npm ERR! errno 1
remote: npm ERR! obento_takeout_app@1.0.0 build: `cd frontend && npm install && npm run build && cd ..`
remote: npm ERR! Exit status 1
remote: npm ERR!
remote: npm ERR! Failed at the obento_takeout_app@1.0.0 build script.
remote: npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
remote:
remote: npm ERR! A complete log of this run can be found in:
remote: npm ERR!     /tmp/npmcache.s4Cu1/_logs/2022-05-25T05_05_25_291Z-debug.log
remote: npm ERR! code ELIFECYCLE
remote: npm ERR! errno 1
remote: npm ERR! obento_takeout_app@1.0.0 heroku-postbuild: `npm run build && npm run deploy && echo 'Client built!'`
remote: npm ERR! Exit status 1
remote: npm ERR!
remote: npm ERR! Failed at the obento_takeout_app@1.0.0 heroku-postbuild script.
remote: npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
remote:
remote: npm ERR! A complete log of this run can be found in:
remote: npm ERR!     /tmp/npmcache.s4Cu1/_logs/2022-05-25T05_05_25_305Z-debug.log
remote:
remote: -----> Build failed
remote:
remote:        We're sorry this build is failing! You can troubleshoot common issues here:
remote:        https://devcenter.heroku.com/articles/troubleshooting-node-deploys
remote:
remote:        If you're stuck, please submit a ticket so we can help:
remote:        https://help.heroku.com/
remote:
remote:        Love,
remote:        Heroku
remote:
remote:  !     Push rejected, failed to compile Node.js app.
remote:
remote:  !     Push failed
remote:  !
remote:  ! ## Warning - The same version of this code has already been built: ff14f4f9aaf241ca810dd22efd3439728aa3ef9b
remote:  !
remote:  ! We have detected that you have triggered a build from source code with version ff14f4f9aaf241ca810dd22efd3439728aa3ef9b
remote:  ! at least twice. One common cause of this behavior is attempting to deploy code from a different branch.
remote:  !
remote:  ! If you are developing on a branch and deploying via git you must run:
remote:  !
remote:  !     git push heroku <branchname>:main
remote:  !
remote:  ! This article goes into details on the behavior:
remote:  !   https://devcenter.heroku.com/articles/duplicate-build-version
remote:
remote: Verifying deploy...
remote:
remote: !	Push rejected to obento-takeout-app.
remote:
To https://git.heroku.com/obento-takeout-app.git
 ! [remote rejected] HEAD -> main (pre-receive hook declined)
```
