### PR TITLE
[フロント]FoodOrderModalの個数がリセットされないバグを修正

### DIFF
--- a/frontend/src/components/organisms/food/FoodOrderModal.tsx
+++ b/frontend/src/components/organisms/food/FoodOrderModal.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable arrow-body-style */
-import { memo, useState, VFC } from 'react';
+import { memo, useEffect, useState, VFC } from 'react';
 import { FormControl } from '@chakra-ui/form-control';
 import { Spacer, Stack, Text } from '@chakra-ui/layout';
 import {
@@ -97,6 +97,10 @@ export const FoodOrderModal: VFC<Props> = memo((props) => {
   };
 
   const variant = useBreakpointValue({ base: 'sm', md: 'lg' });
+
+  useEffect(() => {
+    setCount(1);
+  }, [onClose]);
 
   return (
     <>


### PR DESCRIPTION
## issue
close #174 

## 実装の目的と概要
- FoodOrderModalを閉じた際、個数がリセットされないバグがあったので修正

## 実装内容(技術的な点を記載)
- useEffectでonCloseされた時にリセットするよう、機能追加


## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] ローカル環境でrspecを実行してfailure, errorが出力されていないか(pendingはOK)
```
rspec spec/models
rspec spec/requests
```
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか


